### PR TITLE
refactor: test코드 exception CoreException error type으로 구체화

### DIFF
--- a/src/test/java/com/example/hhplus/concert/application/ConcertFacadeTest.java
+++ b/src/test/java/com/example/hhplus/concert/application/ConcertFacadeTest.java
@@ -10,6 +10,7 @@ import com.example.hhplus.concert.domain.concert.model.ConcertSeat;
 import com.example.hhplus.concert.domain.concert.model.Reservation;
 import com.example.hhplus.concert.domain.concert.model.ReservationStatus;
 import com.example.hhplus.concert.domain.payment.model.Payment;
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.user.model.User;
 import com.example.hhplus.concert.domain.user.model.Wallet;
@@ -74,13 +75,12 @@ class ConcertFacadeTest {
       final Long concertId = null;
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.getReservableConcertSchedules(concertId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -90,12 +90,12 @@ class ConcertFacadeTest {
       final Long concertId = 1L;
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.getReservableConcertSchedules(concertId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.Concert.CONCERT_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_NOT_FOUND);
     }
 
     @Test
@@ -121,18 +121,13 @@ class ConcertFacadeTest {
           Concert.builder().title("title").description("description").build());
       final Long concertId = concert.getId();
 
-      final List<ConcertSchedule> concertSchedules =
-          concertScheduleJpaRepository.saveAll(
-              List.of(
-                  ConcertSchedule.builder().concertId(concertId)
-                      .concertAt(LocalDateTime.now().plusDays(1))
-                      .reservationStartAt(LocalDateTime.now())
-                      .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build(),
-                  ConcertSchedule.builder().concertId(concertId)
-                      .concertAt(LocalDateTime.now().plusDays(2))
-                      .reservationStartAt(LocalDateTime.now())
-                      .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build()
-              ));
+      final List<ConcertSchedule> concertSchedules = concertScheduleJpaRepository.saveAll(List.of(
+          ConcertSchedule.builder().concertId(concertId).concertAt(LocalDateTime.now().plusDays(1))
+              .reservationStartAt(LocalDateTime.now())
+              .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build(),
+          ConcertSchedule.builder().concertId(concertId).concertAt(LocalDateTime.now().plusDays(2))
+              .reservationStartAt(LocalDateTime.now())
+              .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build()));
 
       // when
       final List<ConcertSchedule> result = concertFacade.getReservableConcertSchedules(concertId);
@@ -165,13 +160,13 @@ class ConcertFacadeTest {
       final Long concertScheduleId = null;
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.getReservableConcertSeats(concertScheduleId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -181,13 +176,12 @@ class ConcertFacadeTest {
       final Long concertScheduleId = 1L;
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.getReservableConcertSeats(concertScheduleId);
       });
 
       // then
-      assertThat(result.getMessage())
-          .isEqualTo(ErrorType.Concert.CONCERT_SCHEDULE_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SCHEDULE_NOT_FOUND);
     }
 
     @Test
@@ -199,20 +193,19 @@ class ConcertFacadeTest {
       final Long concertId = concert.getId();
 
       final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-          ConcertSchedule.builder().concertId(concertId)
-              .concertAt(LocalDateTime.now().plusDays(1))
+          ConcertSchedule.builder().concertId(concertId).concertAt(LocalDateTime.now().plusDays(1))
               .reservationStartAt(LocalDateTime.now().plusMinutes(1))
               .reservationEndAt(LocalDateTime.now().plusMinutes(2)).build());
       final Long concertScheduleId = concertSchedule.getId();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.getReservableConcertSeats(concertScheduleId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE);
     }
 
     @Test
@@ -224,13 +217,13 @@ class ConcertFacadeTest {
       final Long concertId = concert.getId();
 
       final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-          ConcertSchedule.builder().concertId(concertId)
-              .concertAt(LocalDateTime.now().plusDays(1))
+          ConcertSchedule.builder().concertId(concertId).concertAt(LocalDateTime.now().plusDays(1))
               .reservationStartAt(LocalDateTime.now())
               .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
       final Long concertScheduleId = concertSchedule.getId();
-      concertSeatJpaRepository.save(ConcertSeat.builder().concertScheduleId(concertScheduleId)
-          .number(1).price(100).isReserved(true).build());
+      concertSeatJpaRepository.save(
+          ConcertSeat.builder().concertScheduleId(concertScheduleId).number(1).price(100)
+              .isReserved(true).build());
 
       // when
       final List<ConcertSeat> result = concertFacade.getReservableConcertSeats(concertScheduleId);
@@ -248,8 +241,7 @@ class ConcertFacadeTest {
       final Long concertId = concert.getId();
 
       final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-          ConcertSchedule.builder().concertId(concertId)
-              .concertAt(LocalDateTime.now().plusDays(1))
+          ConcertSchedule.builder().concertId(concertId).concertAt(LocalDateTime.now().plusDays(1))
               .reservationStartAt(LocalDateTime.now())
               .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
       final Long concertScheduleId = concertSchedule.getId();
@@ -257,13 +249,11 @@ class ConcertFacadeTest {
       ConcertSeat.builder().concertScheduleId(concertScheduleId).number(1).price(100)
           .isReserved(true).build();
 
-      final List<ConcertSeat> concertSeats = concertSeatJpaRepository.saveAll(
-          List.of(
-              ConcertSeat.builder().concertScheduleId(concertScheduleId).number(1).price(100)
-                  .isReserved(false).build(),
-              ConcertSeat.builder().concertScheduleId(concertScheduleId).number(2).price(200)
-                  .isReserved(false).build()
-          ));
+      final List<ConcertSeat> concertSeats = concertSeatJpaRepository.saveAll(List.of(
+          ConcertSeat.builder().concertScheduleId(concertScheduleId).number(1).price(100)
+              .isReserved(false).build(),
+          ConcertSeat.builder().concertScheduleId(concertScheduleId).number(2).price(200)
+              .isReserved(false).build()));
 
       // when
       final List<ConcertSeat> result = concertFacade.getReservableConcertSeats(concertScheduleId);
@@ -303,13 +293,13 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeatWithPessimisticLock(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -320,13 +310,12 @@ class ConcertFacadeTest {
         final Long userId = null;
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeatWithPessimisticLock(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -337,12 +326,12 @@ class ConcertFacadeTest {
         final Long userId = 1L;
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeatWithPessimisticLock(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.User.USER_NOT_FOUND.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
       }
 
       @Test
@@ -354,13 +343,12 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeatWithPessimisticLock(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_NOT_FOUND.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_FOUND);
       }
 
       @Test
@@ -386,13 +374,13 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeatWithPessimisticLock(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE);
       }
 
       @Test
@@ -405,8 +393,7 @@ class ConcertFacadeTest {
 
         final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
             ConcertSchedule.builder().concertId(concertId)
-                .concertAt(LocalDateTime.now().plusDays(1))
-                .reservationStartAt(LocalDateTime.now())
+                .concertAt(LocalDateTime.now().plusDays(1)).reservationStartAt(LocalDateTime.now())
                 .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
         final Long concertScheduleId = concertSchedule.getId();
 
@@ -418,13 +405,13 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeatWithPessimisticLock(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_ALREADY_RESERVED.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ALREADY_RESERVED);
       }
 
       @Test
@@ -437,8 +424,7 @@ class ConcertFacadeTest {
 
         final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
             ConcertSchedule.builder().concertId(concertId)
-                .concertAt(LocalDateTime.now().plusDays(1))
-                .reservationStartAt(LocalDateTime.now())
+                .concertAt(LocalDateTime.now().plusDays(1)).reservationStartAt(LocalDateTime.now())
                 .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
         final Long concertScheduleId = concertSchedule.getId();
 
@@ -451,8 +437,7 @@ class ConcertFacadeTest {
 
         // when
         final Reservation result = concertFacade.reserveConcertSeatWithPessimisticLock(
-            concertSeatId,
-            userId);
+            concertSeatId, userId);
 
         // then
         assertThat(result.getId()).isNotNull();
@@ -482,13 +467,13 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeat(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -499,13 +484,12 @@ class ConcertFacadeTest {
         final Long userId = null;
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeat(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -516,12 +500,12 @@ class ConcertFacadeTest {
         final Long userId = 1L;
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeat(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.User.USER_NOT_FOUND.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
       }
 
       @Test
@@ -533,13 +517,12 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeat(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_NOT_FOUND.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_FOUND);
       }
 
       @Test
@@ -565,13 +548,13 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeat(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE);
       }
 
       @Test
@@ -584,8 +567,7 @@ class ConcertFacadeTest {
 
         final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
             ConcertSchedule.builder().concertId(concertId)
-                .concertAt(LocalDateTime.now().plusDays(1))
-                .reservationStartAt(LocalDateTime.now())
+                .concertAt(LocalDateTime.now().plusDays(1)).reservationStartAt(LocalDateTime.now())
                 .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
         final Long concertScheduleId = concertSchedule.getId();
 
@@ -597,13 +579,13 @@ class ConcertFacadeTest {
         final Long userId = user.getId();
 
         // when
-        final Exception result = assertThrows(Exception.class, () -> {
+        final CoreException result = assertThrows(CoreException.class, () -> {
           concertFacade.reserveConcertSeat(concertSeatId, userId);
         });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_ALREADY_RESERVED.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ALREADY_RESERVED);
       }
 
       @Test
@@ -616,8 +598,7 @@ class ConcertFacadeTest {
 
         final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
             ConcertSchedule.builder().concertId(concertId)
-                .concertAt(LocalDateTime.now().plusDays(1))
-                .reservationStartAt(LocalDateTime.now())
+                .concertAt(LocalDateTime.now().plusDays(1)).reservationStartAt(LocalDateTime.now())
                 .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
         final Long concertScheduleId = concertSchedule.getId();
 
@@ -661,13 +642,13 @@ class ConcertFacadeTest {
       final Long userId = 1L;
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(
+          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -676,19 +657,17 @@ class ConcertFacadeTest {
       // given
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(1L).userId(1L).reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.WAITING)
-              .build());
+              .status(ReservationStatus.WAITING).build());
       final Long reservationId = reservation.getId();
       final Long userId = null;
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_USER_NOT_MATCHED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_USER_NOT_MATCHED);
     }
 
     @Test
@@ -699,13 +678,12 @@ class ConcertFacadeTest {
       final Long userId = 1L;
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage())
-          .isEqualTo(ErrorType.Concert.RESERVATION_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_NOT_FOUND);
     }
 
 
@@ -715,20 +693,17 @@ class ConcertFacadeTest {
       // given
       final Long userId = 1L;
       final Reservation reservation = reservationJpaRepository.save(
-          Reservation.builder().concertSeatId(1L).userId(userId)
-              .reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.CONFIRMED)
-              .build());
+          Reservation.builder().concertSeatId(1L).userId(userId).reservedAt(LocalDateTime.now())
+              .status(ReservationStatus.CONFIRMED).build());
       final Long reservationId = reservation.getId();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_PAID.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_PAID);
     }
 
     @Test
@@ -743,25 +718,21 @@ class ConcertFacadeTest {
 
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
           ConcertSeat.builder().concertScheduleId(1L).number(1).price(wallet.getAmount() - 1)
-              .isReserved(true)
-              .build());
+              .isReserved(true).build());
       final Long concertSeatId = concertSeat.getId();
 
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(concertSeatId).userId(userId)
-              .reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.WAITING)
-              .build());
+              .reservedAt(LocalDateTime.now()).status(ReservationStatus.WAITING).build());
       final Long reservationId = reservation.getId();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId + 1);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_USER_NOT_MATCHED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_USER_NOT_MATCHED);
     }
 
     @Test
@@ -771,22 +742,20 @@ class ConcertFacadeTest {
       final Long userId = 1L;
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(1L).userId(userId).reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.WAITING)
-              .build());
+              .status(ReservationStatus.WAITING).build());
       final Long reservationId = reservation.getId();
 
       concertSeatJpaRepository.save(
-          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100)
-              .isReserved(true)
+          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100).isReserved(true)
               .build());
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.USER_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
     }
 
     @Test
@@ -798,18 +767,16 @@ class ConcertFacadeTest {
 
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(1L).userId(userId).reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.WAITING)
-              .build());
+              .status(ReservationStatus.WAITING).build());
       final Long reservationId = reservation.getId();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_FOUND);
     }
 
 
@@ -825,24 +792,21 @@ class ConcertFacadeTest {
 
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
           ConcertSeat.builder().concertScheduleId(1L).number(1).price(wallet.getAmount() + 1)
-              .isReserved(true)
-              .build());
+              .isReserved(true).build());
       final Long concertSeatId = concertSeat.getId();
 
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(concertSeatId).userId(userId)
-              .reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.WAITING)
-              .build());
+              .reservedAt(LocalDateTime.now()).status(ReservationStatus.WAITING).build());
       final Long reservationId = reservation.getId();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.NOT_ENOUGH_BALANCE.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.NOT_ENOUGH_BALANCE);
     }
 
     @Test
@@ -853,26 +817,22 @@ class ConcertFacadeTest {
       final Long userId = user.getId();
 
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
-          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100)
-              .isReserved(false)
+          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100).isReserved(false)
               .build());
       final Long concertSeatId = concertSeat.getId();
 
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(concertSeatId).userId(userId)
-              .reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.WAITING)
-              .build());
+              .reservedAt(LocalDateTime.now()).status(ReservationStatus.WAITING).build());
       final Long reservationId = reservation.getId();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED);
     }
 
     @Test
@@ -887,25 +847,21 @@ class ConcertFacadeTest {
 
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
           ConcertSeat.builder().concertScheduleId(1L).number(1).price(wallet.getAmount() - 1)
-              .isReserved(true)
-              .build());
+              .isReserved(true).build());
       final Long concertSeatId = concertSeat.getId();
 
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(concertSeatId).userId(userId)
-              .reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.CANCELED)
-              .build());
+              .reservedAt(LocalDateTime.now()).status(ReservationStatus.CANCELED).build());
       final Long reservationId = reservation.getId();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.payReservation(reservationId, userId);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_CANCELED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_CANCELED);
     }
 
     @Test
@@ -920,15 +876,12 @@ class ConcertFacadeTest {
 
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
           ConcertSeat.builder().concertScheduleId(1L).number(1).price(wallet.getAmount() - 1)
-              .isReserved(true)
-              .build());
+              .isReserved(true).build());
       final Long concertSeatId = concertSeat.getId();
 
       final Reservation reservation = reservationJpaRepository.save(
           Reservation.builder().concertSeatId(concertSeatId).userId(userId)
-              .reservedAt(LocalDateTime.now())
-              .status(ReservationStatus.WAITING)
-              .build());
+              .reservedAt(LocalDateTime.now()).status(ReservationStatus.WAITING).build());
       final Long reservationId = reservation.getId();
 
       // when
@@ -960,25 +913,21 @@ class ConcertFacadeTest {
     void shouldThrowConcertSeatNotReservedException() {
       // given
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
-          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100)
-              .isReserved(false)
+          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100).isReserved(false)
               .build());
 
       reservationJpaRepository.save(
-          Reservation.builder().concertSeatId(concertSeat.getId()).userId(1L)
-              .reservedAt(
+          Reservation.builder().concertSeatId(concertSeat.getId()).userId(1L).reservedAt(
                   LocalDateTime.now().minusMinutes(ConcertConstants.RESERVATION_EXPIRATION_MINUTES))
-              .status(ReservationStatus.WAITING)
-              .build());
+              .status(ReservationStatus.WAITING).build());
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         concertFacade.expireReservations();
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED);
     }
 
     @Test
@@ -986,16 +935,13 @@ class ConcertFacadeTest {
     void shouldSuccessfullyExpireReservations() {
       // given
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
-          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100)
-              .isReserved(true)
+          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100).isReserved(true)
               .build());
 
       reservationJpaRepository.save(
-          Reservation.builder().concertSeatId(concertSeat.getId()).userId(1L)
-              .reservedAt(LocalDateTime.now()
-                  .minusMinutes(ConcertConstants.RESERVATION_EXPIRATION_MINUTES - 1))
-              .status(ReservationStatus.WAITING)
-              .build());
+          Reservation.builder().concertSeatId(concertSeat.getId()).userId(1L).reservedAt(
+                  LocalDateTime.now().minusMinutes(ConcertConstants.RESERVATION_EXPIRATION_MINUTES - 1))
+              .status(ReservationStatus.WAITING).build());
 
       // when
       concertFacade.expireReservations();
@@ -1011,16 +957,13 @@ class ConcertFacadeTest {
     void shouldSuccessfullyExpireReservationsWithExpiredReservations() {
       // given
       final ConcertSeat concertSeat = concertSeatJpaRepository.save(
-          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100)
-              .isReserved(true)
+          ConcertSeat.builder().concertScheduleId(1L).number(1).price(100).isReserved(true)
               .build());
 
       reservationJpaRepository.save(
-          Reservation.builder().concertSeatId(concertSeat.getId()).userId(1L)
-              .reservedAt(LocalDateTime.now()
-                  .minusMinutes(ConcertConstants.RESERVATION_EXPIRATION_MINUTES + 1))
-              .status(ReservationStatus.WAITING)
-              .build());
+          Reservation.builder().concertSeatId(concertSeat.getId()).userId(1L).reservedAt(
+                  LocalDateTime.now().minusMinutes(ConcertConstants.RESERVATION_EXPIRATION_MINUTES + 1))
+              .status(ReservationStatus.WAITING).build());
 
       // when
       concertFacade.expireReservations();

--- a/src/test/java/com/example/hhplus/concert/application/UserFacadeTest.java
+++ b/src/test/java/com/example/hhplus/concert/application/UserFacadeTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.user.UserConstants;
 import com.example.hhplus.concert.domain.user.model.User;
@@ -49,12 +50,11 @@ class UserFacadeTest {
       final Integer amount = 1000;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -68,12 +68,11 @@ class UserFacadeTest {
       final Integer amount = 1000;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.WALLET_NOT_MATCH_USER.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
     }
 
     @Test
@@ -87,12 +86,11 @@ class UserFacadeTest {
       final Integer amount = null;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_NOT_BE_NULL.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -106,12 +104,11 @@ class UserFacadeTest {
       final Integer amount = -1;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -125,12 +122,11 @@ class UserFacadeTest {
       final Integer amount = 0;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -142,11 +138,11 @@ class UserFacadeTest {
       final Integer amount = 1000;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.USER_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
     }
 
     @Test
@@ -158,11 +154,11 @@ class UserFacadeTest {
       final Integer amount = 1000;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(user.getId(), walletId, amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND);
     }
 
 
@@ -177,11 +173,11 @@ class UserFacadeTest {
       final Integer amount = 1000;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
     }
 
     @Test
@@ -193,12 +189,11 @@ class UserFacadeTest {
       final Integer amount = -1;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -210,12 +205,11 @@ class UserFacadeTest {
       final Integer amount = 0;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -228,11 +222,11 @@ class UserFacadeTest {
       final Integer amount = UserConstants.MAX_WALLET_AMOUNT + 1;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT);
     }
 
     @Test
@@ -264,12 +258,11 @@ class UserFacadeTest {
       final Long userId = null;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.getWallet(userId));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -279,11 +272,11 @@ class UserFacadeTest {
       final Long userId = 1L;
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.getWallet(userId));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.USER_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
     }
 
     @Test
@@ -293,11 +286,11 @@ class UserFacadeTest {
       final User user = userJpaRepository.save(User.builder().name("name").build());
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> userFacade.getWallet(user.getId()));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/application/WaitingQueueFacadeTest.java
+++ b/src/test/java/com/example/hhplus/concert/application/WaitingQueueFacadeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.example.hhplus.concert.domain.concert.model.Concert;
 import com.example.hhplus.concert.domain.concert.model.ConcertSchedule;
 import com.example.hhplus.concert.domain.concert.model.ConcertSeat;
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.waitingqueue.WaitingQueueConstants;
 import com.example.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
@@ -64,14 +65,12 @@ class WaitingQueueFacadeTest {
       final Long concertId = null;
 
       // when
-      final Exception result = assertThrows(
-          Exception.class, () -> {
-            waitingQueueFacade.createWaitingQueueToken(concertId);
-          });
+      final CoreException result = assertThrows(CoreException.class, () -> {
+        waitingQueueFacade.createWaitingQueueToken(concertId);
+      });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL
-          .getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -106,15 +105,13 @@ class WaitingQueueFacadeTest {
       final String waitingQueueTokenUuid = null;
 
       // when
-      final Exception result = assertThrows(
-          Exception.class, () -> {
-            waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
-          });
+      final CoreException result = assertThrows(CoreException.class, () -> {
+        waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
+      });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-              .getMessage());
+      assertThat(result.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -124,15 +121,13 @@ class WaitingQueueFacadeTest {
       final String waitingQueueTokenUuid = "";
 
       // when
-      final Exception result = assertThrows(
-          Exception.class, () -> {
-            waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
-          });
+      final CoreException result = assertThrows(CoreException.class, () -> {
+        waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
+      });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-              .getMessage());
+      assertThat(result.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -142,14 +137,12 @@ class WaitingQueueFacadeTest {
       final String waitingQueueTokenUuid = UUID.randomUUID().toString();
 
       // when
-      final Exception result = assertThrows(
-          Exception.class, () -> {
-            waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
-          });
+      final CoreException result = assertThrows(CoreException.class, () -> {
+        waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
+      });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_NOT_FOUND
-          .getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_NOT_FOUND);
     }
 
     @Test
@@ -157,22 +150,17 @@ class WaitingQueueFacadeTest {
     void shouldThrowBusinessExceptionWhenGetWaitingQueuePositionWithExpiredToken() {
       // given
       final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-      waitingQueueJpaRepository.save(WaitingQueue.builder()
-          .uuid(waitingQueueTokenUuid)
-          .concertId(1L)
-          .status(WaitingQueueStatus.EXPIRED)
-          .expiredAt(LocalDateTime.now())
-          .build());
+      waitingQueueJpaRepository.save(
+          WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+              .status(WaitingQueueStatus.EXPIRED).expiredAt(LocalDateTime.now()).build());
 
       // when
-      final Exception result = assertThrows(
-          Exception.class, () -> {
-            waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
-          });
+      final CoreException result = assertThrows(CoreException.class, () -> {
+        waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
+      });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-          .getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
     }
 
     @Test
@@ -180,22 +168,17 @@ class WaitingQueueFacadeTest {
     void shouldThrowBusinessExceptionWhenGetWaitingQueuePositionWithExpiredTokenByExpiredAt() {
       // given
       final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-      waitingQueueJpaRepository.save(WaitingQueue.builder()
-          .uuid(waitingQueueTokenUuid)
-          .concertId(1L)
-          .status(WaitingQueueStatus.WAITING)
-          .expiredAt(LocalDateTime.now())
-          .build());
+      waitingQueueJpaRepository.save(
+          WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+              .status(WaitingQueueStatus.WAITING).expiredAt(LocalDateTime.now()).build());
 
       // when
-      final Exception result = assertThrows(
-          Exception.class, () -> {
-            waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
-          });
+      final CoreException result = assertThrows(CoreException.class, () -> {
+        waitingQueueFacade.getWaitingQueueWithPosition(waitingQueueTokenUuid);
+      });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-          .getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
     }
 
     @Test
@@ -203,16 +186,14 @@ class WaitingQueueFacadeTest {
     void shouldGetWaitingQueueWithPositionWhenStatusIsProcessing() {
       // given
       final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-      final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(WaitingQueue.builder()
-          .uuid(waitingQueueTokenUuid)
-          .concertId(1L)
-          .status(WaitingQueueStatus.PROCESSING)
-          .expiredAt(LocalDateTime.now().plusMinutes(1))
-          .build());
+      final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(
+          WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+              .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+              .build());
 
       // when
-      final WaitingQueueWithPosition result = waitingQueueFacade
-          .getWaitingQueueWithPosition(waitingQueueTokenUuid);
+      final WaitingQueueWithPosition result = waitingQueueFacade.getWaitingQueueWithPosition(
+          waitingQueueTokenUuid);
 
       // then
       assertThat(result.id()).isEqualTo(waitingQueue.getId());
@@ -229,22 +210,18 @@ class WaitingQueueFacadeTest {
     @DisplayName("대기열 토큰 순서 조회 성공 - 대기열 상태가 WAITING")
     void shouldGetWaitingQueueWithPositionWhenStatusIsWaiting() {
       // given
-      waitingQueueJpaRepository.save(WaitingQueue.builder()
-          .uuid(UUID.randomUUID().toString())
-          .concertId(1L)
-          .status(WaitingQueueStatus.WAITING)
-          .build());
+      waitingQueueJpaRepository.save(
+          WaitingQueue.builder().uuid(UUID.randomUUID().toString()).concertId(1L)
+              .status(WaitingQueueStatus.WAITING).build());
 
       final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-      final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(WaitingQueue.builder()
-          .uuid(waitingQueueTokenUuid)
-          .concertId(1L)
-          .status(WaitingQueueStatus.WAITING)
-          .build());
+      final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(
+          WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+              .status(WaitingQueueStatus.WAITING).build());
 
       // when
-      final WaitingQueueWithPosition result = waitingQueueFacade
-          .getWaitingQueueWithPosition(waitingQueueTokenUuid);
+      final WaitingQueueWithPosition result = waitingQueueFacade.getWaitingQueueWithPosition(
+          waitingQueueTokenUuid);
 
       // then
       assertThat(result.id()).isEqualTo(waitingQueue.getId());
@@ -274,16 +251,14 @@ class WaitingQueueFacadeTest {
         final Long concertId = 1L;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  concertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              concertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
       }
 
       @Test
@@ -294,16 +269,14 @@ class WaitingQueueFacadeTest {
         final Long concertId = 1L;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  concertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              concertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
       }
 
       @Test
@@ -311,24 +284,20 @@ class WaitingQueueFacadeTest {
       void shouldThrowBusinessExceptionWhenValidateProcessingWithNullConcertId() {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+                .build());
         final Long concertId = null;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  concertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              concertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID);
       }
 
       @Test
@@ -339,15 +308,13 @@ class WaitingQueueFacadeTest {
         final Long concertId = 1L;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  concertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              concertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_NOT_FOUND
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_NOT_FOUND);
       }
 
       @Test
@@ -356,23 +323,18 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long concertId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(concertId)
-            .status(WaitingQueueStatus.EXPIRED)
-            .expiredAt(LocalDateTime.now())
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(concertId)
+                .status(WaitingQueueStatus.EXPIRED).expiredAt(LocalDateTime.now()).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  concertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              concertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
       }
 
       @Test
@@ -381,22 +343,18 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long concertId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(concertId)
-            .status(WaitingQueueStatus.WAITING)
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(concertId)
+                .status(WaitingQueueStatus.WAITING).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  concertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              concertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS);
       }
 
       @Test
@@ -405,23 +363,18 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long concertId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(concertId)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now())
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(concertId)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now()).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  concertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              concertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
 
       }
 
@@ -432,23 +385,19 @@ class WaitingQueueFacadeTest {
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long concertId = 1L;
         final Long notMatchConcertId = 2L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(concertId)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(concertId)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+                .build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
-                  notMatchConcertId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
+              notMatchConcertId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID);
       }
 
       @Test
@@ -457,12 +406,10 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long concertId = 1L;
-        final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(concertId)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
+        final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(concertId)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+                .build());
 
         // when
         waitingQueueFacade.validateWaitingQueueProcessingAndConcertId(waitingQueueTokenUuid,
@@ -487,16 +434,14 @@ class WaitingQueueFacadeTest {
         final Long scheduleId = 1L;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
-                  scheduleId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
+              scheduleId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
       }
 
       @Test
@@ -507,16 +452,14 @@ class WaitingQueueFacadeTest {
         final Long scheduleId = 1L;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
-                  scheduleId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
+              scheduleId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
       }
 
       @Test
@@ -524,25 +467,21 @@ class WaitingQueueFacadeTest {
       void shouldThrowBusinessExceptionWhenValidateProcessingWithNullScheduleId() {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+                .build());
         final Long scheduleId = null;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
-                  scheduleId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
+              scheduleId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL);
       }
 
 
@@ -552,23 +491,18 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long scheduleId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.EXPIRED)
-            .expiredAt(LocalDateTime.now())
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.EXPIRED).expiredAt(LocalDateTime.now()).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
-                  scheduleId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
+              scheduleId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
       }
 
       @Test
@@ -577,22 +511,18 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long scheduleId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.WAITING)
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.WAITING).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
-                  scheduleId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
+              scheduleId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS);
       }
 
       @Test
@@ -601,23 +531,18 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long scheduleId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now())
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now()).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
-                  scheduleId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
+              scheduleId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
 
       }
 
@@ -627,31 +552,24 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long notMatchConcertId = 2L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+                .build());
         final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-            ConcertSchedule.builder()
-                .concertId(notMatchConcertId)
-                .concertAt(LocalDateTime.now())
-                .reservationStartAt(LocalDateTime.now())
-                .reservationEndAt(LocalDateTime.now())
+            ConcertSchedule.builder().concertId(notMatchConcertId).concertAt(LocalDateTime.now())
+                .reservationStartAt(LocalDateTime.now()).reservationEndAt(LocalDateTime.now())
                 .build());
         final Long scheduleId = concertSchedule.getId();
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
-                  scheduleId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndScheduleId(waitingQueueTokenUuid,
+              scheduleId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID);
       }
 
       @Test
@@ -659,18 +577,13 @@ class WaitingQueueFacadeTest {
       void shouldThrowBusinessExceptionWhenValidateProcessingWithProcessingToken() {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-        final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
+        final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+                .build());
         final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-            ConcertSchedule.builder()
-                .concertId(1L)
-                .concertAt(LocalDateTime.now())
-                .reservationStartAt(LocalDateTime.now())
-                .reservationEndAt(LocalDateTime.now())
+            ConcertSchedule.builder().concertId(1L).concertAt(LocalDateTime.now())
+                .reservationStartAt(LocalDateTime.now()).reservationEndAt(LocalDateTime.now())
                 .build());
         final Long scheduleId = concertSchedule.getId();
 
@@ -698,16 +611,13 @@ class WaitingQueueFacadeTest {
         final Long seatId = 1L;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-                  seatId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
       }
 
       @Test
@@ -718,16 +628,13 @@ class WaitingQueueFacadeTest {
         final Long seatId = 1L;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-                  seatId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
       }
 
       @Test
@@ -735,25 +642,20 @@ class WaitingQueueFacadeTest {
       void shouldThrowBusinessExceptionWhenValidateProcessingWithNullSeatId() {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+                .build());
         final Long seatId = null;
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-                  seatId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL
-                .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -762,23 +664,17 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long seatId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.EXPIRED)
-            .expiredAt(LocalDateTime.now())
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.EXPIRED).expiredAt(LocalDateTime.now()).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-                  seatId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
       }
 
       @Test
@@ -787,22 +683,17 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long seatId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.WAITING)
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.WAITING).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-                  seatId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS);
       }
 
       @Test
@@ -811,23 +702,17 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long seatId = 1L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now())
-            .build());
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now()).build());
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-                  seatId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED
-            .getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
 
       }
 
@@ -837,37 +722,26 @@ class WaitingQueueFacadeTest {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
         final Long notMatchConcertId = 2L;
-        waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
-        final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-            ConcertSchedule.builder()
-                .concertId(notMatchConcertId)
-                .concertAt(LocalDateTime.now())
-                .reservationStartAt(LocalDateTime.now())
-                .reservationEndAt(LocalDateTime.now())
+        waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
                 .build());
-        final ConcertSeat concertSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
-            .concertScheduleId(concertSchedule.getId())
-            .number(1)
-            .price(10000)
-            .isReserved(false)
-            .build());
+        final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder().concertId(notMatchConcertId).concertAt(LocalDateTime.now())
+                .reservationStartAt(LocalDateTime.now()).reservationEndAt(LocalDateTime.now())
+                .build());
+        final ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder().concertScheduleId(concertSchedule.getId()).number(1).price(10000)
+                .isReserved(false).build());
         final Long seatId = concertSeat.getId();
 
         // when
-        final Exception result = assertThrows(
-            Exception.class, () -> {
-              waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-                  seatId);
-            });
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
+        });
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.Concert.INVALID_CONCERT_ID.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID);
       }
 
       @Test
@@ -875,30 +749,21 @@ class WaitingQueueFacadeTest {
       void shouldThrowBusinessExceptionWhenValidateProcessingWithProcessingToken() {
         // given
         final String waitingQueueTokenUuid = UUID.randomUUID().toString();
-        final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(WaitingQueue.builder()
-            .uuid(waitingQueueTokenUuid)
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
-            .build());
-        final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-            ConcertSchedule.builder()
-                .concertId(1L)
-                .concertAt(LocalDateTime.now())
-                .reservationStartAt(LocalDateTime.now())
-                .reservationEndAt(LocalDateTime.now())
+        final WaitingQueue waitingQueue = waitingQueueJpaRepository.save(
+            WaitingQueue.builder().uuid(waitingQueueTokenUuid).concertId(1L)
+                .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
                 .build());
-        final ConcertSeat concertSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
-            .concertScheduleId(concertSchedule.getId())
-            .number(1)
-            .price(10000)
-            .isReserved(false)
-            .build());
+        final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder().concertId(1L).concertAt(LocalDateTime.now())
+                .reservationStartAt(LocalDateTime.now()).reservationEndAt(LocalDateTime.now())
+                .build());
+        final ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder().concertScheduleId(concertSchedule.getId()).number(1).price(10000)
+                .isReserved(false).build());
         final Long seatId = concertSeat.getId();
 
         // when
-        waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid,
-            seatId);
+        waitingQueueFacade.validateWaitingQueueProcessingAndSeatId(waitingQueueTokenUuid, seatId);
 
         // then
         assertThat(waitingQueue.getStatus()).isEqualTo(WaitingQueueStatus.PROCESSING);
@@ -918,26 +783,19 @@ class WaitingQueueFacadeTest {
     @DisplayName("대기열 활성화 성공 - 활성 자리가 없는 경우")
     void shouldSuccessfullyActivateWaitingQueuesWhenNotExistsAvailableSlots() {
       // given
-      final Concert concert = concertJpaRepository.save(Concert.builder()
-          .title("title")
-          .description("description")
-          .build());
+      final Concert concert = concertJpaRepository.save(
+          Concert.builder().title("title").description("description").build());
       final Long concertId = concert.getId();
 
-      IntStream.range(0, WaitingQueueConstants.MAX_PROCESSING_WAITING_QUEUE_COUNT)
-          .forEach(i -> waitingQueueJpaRepository.save(WaitingQueue.builder()
-              .concertId(concertId)
-              .uuid(UUID.randomUUID().toString())
-              .status(WaitingQueueStatus.PROCESSING)
-              .expiredAt(LocalDateTime.now().plusMinutes(1))
-              .build()));
+      IntStream.range(0, WaitingQueueConstants.MAX_PROCESSING_WAITING_QUEUE_COUNT).forEach(
+          i -> waitingQueueJpaRepository.save(
+              WaitingQueue.builder().concertId(concertId).uuid(UUID.randomUUID().toString())
+                  .status(WaitingQueueStatus.PROCESSING)
+                  .expiredAt(LocalDateTime.now().plusMinutes(1)).build()));
       final int waitingQueueCount = 5;
-      IntStream.range(0, waitingQueueCount)
-          .forEach(i -> waitingQueueJpaRepository.save(WaitingQueue.builder()
-              .concertId(concertId)
-              .uuid(UUID.randomUUID().toString())
-              .status(WaitingQueueStatus.WAITING)
-              .build()));
+      IntStream.range(0, waitingQueueCount).forEach(i -> waitingQueueJpaRepository.save(
+          WaitingQueue.builder().concertId(concertId).uuid(UUID.randomUUID().toString())
+              .status(WaitingQueueStatus.WAITING).build()));
 
       // when
       waitingQueueFacade.activateWaitingQueues();
@@ -977,18 +835,13 @@ class WaitingQueueFacadeTest {
     @DisplayName("대기열 활성화 성공 - 대기열이 있는 경우")
     void shouldSuccessfullyActivateWaitingQueuesWhenExistsWaitingQueue() {
       // given
-      final Concert concert = concertJpaRepository.save(Concert.builder()
-          .title("title")
-          .description("description")
-          .build());
+      final Concert concert = concertJpaRepository.save(
+          Concert.builder().title("title").description("description").build());
       final Long concertId = concert.getId();
       final int waitingQueueCount = WaitingQueueConstants.MAX_PROCESSING_WAITING_QUEUE_COUNT + 5;
-      IntStream.range(0, waitingQueueCount)
-          .forEach(i -> waitingQueueJpaRepository.save(WaitingQueue.builder()
-              .concertId(concertId)
-              .uuid(UUID.randomUUID().toString())
-              .status(WaitingQueueStatus.WAITING)
-              .build()));
+      IntStream.range(0, waitingQueueCount).forEach(i -> waitingQueueJpaRepository.save(
+          WaitingQueue.builder().concertId(concertId).uuid(UUID.randomUUID().toString())
+              .status(WaitingQueueStatus.WAITING).build()));
 
       // when
       waitingQueueFacade.activateWaitingQueues();
@@ -1031,28 +884,20 @@ class WaitingQueueFacadeTest {
     @DisplayName("대기열 만료 성공 - 만료 대기열이 있는 경우")
     void shouldSuccessfullyExpireWaitingQueuesWhenExistsExpiredWaitingQueue() {
       // given
-      final Concert concert = concertJpaRepository.save(Concert.builder()
-          .title("title")
-          .description("description")
-          .build());
+      final Concert concert = concertJpaRepository.save(
+          Concert.builder().title("title").description("description").build());
       final Long concertId = concert.getId();
 
       final int expiredWaitingQueueCount = 3;
-      IntStream.range(0, expiredWaitingQueueCount)
-          .forEach(i -> waitingQueueJpaRepository.save(WaitingQueue.builder()
-              .concertId(concertId)
-              .uuid(UUID.randomUUID().toString())
-              .status(WaitingQueueStatus.PROCESSING)
-              .expiredAt(LocalDateTime.now().minusMinutes(1))
+      IntStream.range(0, expiredWaitingQueueCount).forEach(i -> waitingQueueJpaRepository.save(
+          WaitingQueue.builder().concertId(concertId).uuid(UUID.randomUUID().toString())
+              .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().minusMinutes(1))
               .build()));
 
       final int waitingQueueCount = 5;
-      IntStream.range(0, waitingQueueCount)
-          .forEach(i -> waitingQueueJpaRepository.save(WaitingQueue.builder()
-              .concertId(concertId)
-              .uuid(UUID.randomUUID().toString())
-              .status(WaitingQueueStatus.WAITING)
-              .build()));
+      IntStream.range(0, waitingQueueCount).forEach(i -> waitingQueueJpaRepository.save(
+          WaitingQueue.builder().concertId(concertId).uuid(UUID.randomUUID().toString())
+              .status(WaitingQueueStatus.WAITING).build()));
 
       // when
       waitingQueueFacade.expireWaitingQueues();

--- a/src/test/java/com/example/hhplus/concert/domain/concert/dto/ConcertCommandTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/concert/dto/ConcertCommandTest.java
@@ -8,6 +8,7 @@ import com.example.hhplus.concert.domain.concert.dto.ConcertCommand.ConfirmReser
 import com.example.hhplus.concert.domain.concert.dto.ConcertCommand.CreateReservationCommand;
 import com.example.hhplus.concert.domain.concert.dto.ConcertCommand.ReleaseConcertSeatsByIdsCommand;
 import com.example.hhplus.concert.domain.concert.dto.ConcertCommand.ReserveConcertSeatCommand;
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -28,12 +29,12 @@ class ConcertCommandTest {
       final Long concertSeatId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ReserveConcertSeatCommand(concertSeatId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -63,12 +64,12 @@ class ConcertCommandTest {
       final Long userId = 1L;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreateReservationCommand(concertSeatId, userId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -79,12 +80,11 @@ class ConcertCommandTest {
       final Long userId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreateReservationCommand(concertSeatId, userId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -115,12 +115,12 @@ class ConcertCommandTest {
       final Long reservationId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ConfirmReservationCommand(reservationId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -149,12 +149,12 @@ class ConcertCommandTest {
       final List<Long> reservationIds = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CancelReservationsByIdsCommand(reservationIds));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -164,12 +164,12 @@ class ConcertCommandTest {
       final List<Long> reservationIds = List.of();
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CancelReservationsByIdsCommand(reservationIds));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -199,12 +199,12 @@ class ConcertCommandTest {
       final List<Long> concertSeatIds = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ReleaseConcertSeatsByIdsCommand(concertSeatIds));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -214,12 +214,12 @@ class ConcertCommandTest {
       final List<Long> concertSeatIds = List.of();
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ReleaseConcertSeatsByIdsCommand(concertSeatIds));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/concert/dto/ConcertQueryTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/concert/dto/ConcertQueryTest.java
@@ -12,6 +12,7 @@ import com.example.hhplus.concert.domain.concert.dto.ConcertQuery.GetConcertSeat
 import com.example.hhplus.concert.domain.concert.dto.ConcertQuery.GetConcertSeatByIdWithLockQuery;
 import com.example.hhplus.concert.domain.concert.dto.ConcertQuery.GetReservationByIdQuery;
 import com.example.hhplus.concert.domain.concert.dto.ConcertQuery.GetReservationByIdWithLockQuery;
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -35,12 +36,12 @@ class ConcertQueryTest {
         final Long concertId = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetConcertByIdQuery(concertId));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -69,12 +70,12 @@ class ConcertQueryTest {
         final Long concertId = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetConcertByIdWithLockQuery(concertId));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -104,12 +105,12 @@ class ConcertQueryTest {
       final Long concertScheduleId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new GetConcertScheduleByIdQuery(concertScheduleId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -138,12 +139,11 @@ class ConcertQueryTest {
       final Long concertId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new FindReservableConcertSchedulesQuery(concertId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -177,12 +177,12 @@ class ConcertQueryTest {
         final Long concertSeatId = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetConcertSeatByIdQuery(concertSeatId));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -211,12 +211,12 @@ class ConcertQueryTest {
         final Long concertSeatId = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetConcertSeatByIdWithLockQuery(concertSeatId));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -247,12 +247,12 @@ class ConcertQueryTest {
       final Long concertScheduleId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new FindReservableConcertSeatsQuery(concertScheduleId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SCHEDULE_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -286,12 +286,12 @@ class ConcertQueryTest {
         final Long reservationId = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetReservationByIdQuery(reservationId));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -320,12 +320,12 @@ class ConcertQueryTest {
         final Long reservationId = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetReservationByIdWithLockQuery(reservationId));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL);
       }
 
       @Test

--- a/src/test/java/com/example/hhplus/concert/domain/concert/model/ConcertScheduleTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/concert/model/ConcertScheduleTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.concert.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -22,16 +23,15 @@ class ConcertScheduleTest {
       // given
       var concertSchedule = ConcertSchedule.builder()
           .reservationStartAt(LocalDateTime.now().plusDays(1))
-          .reservationEndAt(LocalDateTime.now().plusDays(2))
-          .build();
+          .reservationEndAt(LocalDateTime.now().plusDays(2)).build();
 
       // when
-      Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> concertSchedule.validateReservationTime());
 
       // then
-      assertThat(exception.getMessage()
-          .equals(ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE.getMessage()));
+      assertThat(
+          exception.getErrorType().equals(ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE));
     }
 
     @Test
@@ -40,16 +40,15 @@ class ConcertScheduleTest {
       // given
       var concertSchedule = ConcertSchedule.builder()
           .reservationStartAt(LocalDateTime.now().minusDays(2))
-          .reservationEndAt(LocalDateTime.now().minusDays(1))
-          .build();
+          .reservationEndAt(LocalDateTime.now().minusDays(1)).build();
 
       // when
-      Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> concertSchedule.validateReservationTime());
 
       // then
-      assertThat(exception.getMessage()
-          .equals(ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE.getMessage()));
+      assertThat(
+          exception.getErrorType().equals(ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE));
     }
 
     @Test
@@ -57,10 +56,8 @@ class ConcertScheduleTest {
     void shouldNotThrowExceptionWhenReservable() {
       // given
       var now = LocalDateTime.now();
-      var concertSchedule = ConcertSchedule.builder()
-          .reservationStartAt(now)
-          .reservationEndAt(now.plusSeconds(1))
-          .build();
+      var concertSchedule = ConcertSchedule.builder().reservationStartAt(now)
+          .reservationEndAt(now.plusSeconds(1)).build();
 
       // when
       concertSchedule.validateReservationTime();

--- a/src/test/java/com/example/hhplus/concert/domain/concert/model/ConcertSeatTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/concert/model/ConcertSeatTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.concert.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,26 +20,21 @@ class ConcertSeatTest {
     @DisplayName("예약 실패")
     void shouldThrowExceptionWhenReserve() {
       // given
-      ConcertSeat concertSeat = ConcertSeat.builder()
-          .isReserved(true)
-          .build();
+      ConcertSeat concertSeat = ConcertSeat.builder().isReserved(true).build();
 
       // when
-      Exception exception = assertThrows(Exception.class,
-          concertSeat::reserve);
+      final CoreException exception = assertThrows(CoreException.class, concertSeat::reserve);
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_ALREADY_RESERVED.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.CONCERT_SEAT_ALREADY_RESERVED);
     }
 
     @Test
     @DisplayName("예약 성공")
     void shouldSuccessfullyReserve() {
       // given
-      ConcertSeat concertSeat = ConcertSeat.builder()
-          .isReserved(false)
-          .build();
+      ConcertSeat concertSeat = ConcertSeat.builder().isReserved(false).build();
 
       // when
       concertSeat.reserve();
@@ -57,26 +53,20 @@ class ConcertSeatTest {
     @DisplayName("예약 해지 실패 - 이미 해지된 좌석")
     void shouldThrowExceptionWhenRelease() {
       // given
-      ConcertSeat concertSeat = ConcertSeat.builder()
-          .isReserved(false)
-          .build();
+      ConcertSeat concertSeat = ConcertSeat.builder().isReserved(false).build();
 
       // when
-      Exception exception = assertThrows(Exception.class,
-          concertSeat::release);
+      final CoreException exception = assertThrows(CoreException.class, concertSeat::release);
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED);
     }
 
     @Test
     @DisplayName("예약 해지 성공")
     void shouldSuccessfullyRelease() {
       // given
-      ConcertSeat concertSeat = ConcertSeat.builder()
-          .isReserved(true)
-          .build();
+      ConcertSeat concertSeat = ConcertSeat.builder().isReserved(true).build();
 
       // when
       concertSeat.release();
@@ -95,26 +85,21 @@ class ConcertSeatTest {
     @DisplayName("예약된 좌석 확인 실패")
     void shouldThrowExceptionWhenValidateReserved() {
       // given
-      ConcertSeat concertSeat = ConcertSeat.builder()
-          .isReserved(false)
-          .build();
+      ConcertSeat concertSeat = ConcertSeat.builder().isReserved(false).build();
 
       // when
-      Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           concertSeat::validateReserved);
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_RESERVED);
     }
 
     @Test
     @DisplayName("예약된 좌석 확인 성공")
     void shouldSuccessfullyValidateReserved() {
       // given
-      ConcertSeat concertSeat = ConcertSeat.builder()
-          .isReserved(true)
-          .build();
+      ConcertSeat concertSeat = ConcertSeat.builder().isReserved(true).build();
 
       // when
       concertSeat.validateReserved();

--- a/src/test/java/com/example/hhplus/concert/domain/concert/model/ReservationTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/concert/model/ReservationTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.concert.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,49 +21,36 @@ class ReservationTest {
     @DisplayName("예약 확정 실패 - 이미 확정된 예약")
     void shouldThrowExceptionWhenAlreadyConfirmed() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.CONFIRMED)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.CONFIRMED).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
-          reservation::confirm);
+      final CoreException result = assertThrows(CoreException.class, reservation::confirm);
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_PAID.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_PAID);
     }
 
     @Test
     @DisplayName("예약 확정 실패 - 이미 취소된 예약")
     void shouldThrowExceptionWhenAlreadyCanceled() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.CANCELED)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.CANCELED).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
-          reservation::confirm);
+      final CoreException result = assertThrows(CoreException.class, reservation::confirm);
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_CANCELED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_CANCELED);
     }
 
     @Test
     @DisplayName("예약 확정 성공")
     void shouldSuccessfullyConfirm() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.WAITING)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.WAITING).build();
 
       // when
       reservation.confirm();
@@ -81,49 +69,36 @@ class ReservationTest {
     @DisplayName("예약 취소 실패 - 이미 취소된 예약")
     void shouldThrowExceptionWhenAlreadyCanceled() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.CANCELED)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.CANCELED).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
-          reservation::cancel);
+      final CoreException result = assertThrows(CoreException.class, reservation::cancel);
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_CANCELED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_CANCELED);
     }
 
     @Test
     @DisplayName("예약 취소 실패 - 이미 확정된 예약")
     void shouldThrowExceptionWhenAlreadyConfirmed() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.CONFIRMED)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.CONFIRMED).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
-          reservation::cancel);
+      final CoreException result = assertThrows(CoreException.class, reservation::cancel);
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_PAID.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_PAID);
     }
 
     @Test
     @DisplayName("예약 취소 성공")
     void shouldSuccessfullyCancel() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.WAITING)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.WAITING).build();
 
       // when
       reservation.cancel();
@@ -142,68 +117,53 @@ class ReservationTest {
     @DisplayName("예약 확정 검증 실패 - 사용자 불일치")
     void shouldThrowExceptionWhenUserNotMatched() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.WAITING)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.WAITING).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> reservation.validateConfirmConditions(2L));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_USER_NOT_MATCHED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_USER_NOT_MATCHED);
     }
 
     @Test
     @DisplayName("예약 확정 검증 실패 - 이미 취소된 예약")
     void shouldThrowExceptionWhenAlreadyCanceled() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.CANCELED)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.CANCELED).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> reservation.validateConfirmConditions(1L));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_CANCELED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_CANCELED);
     }
 
     @Test
     @DisplayName("예약 확정 검증 실패 - 이미 확정된 예약")
     void shouldThrowExceptionWhenAlreadyConfirmed() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.CONFIRMED)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.CONFIRMED).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> reservation.validateConfirmConditions(1L));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ALREADY_PAID.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.RESERVATION_ALREADY_PAID);
     }
 
     @Test
     @DisplayName("예약 확정 검증 성공")
     void shouldSuccessfullyValidateConfirmConditions() {
       // given
-      final Reservation reservation = Reservation.builder()
-          .concertSeatId(1L)
-          .userId(1L)
-          .status(ReservationStatus.WAITING)
-          .build();
+      final Reservation reservation = Reservation.builder().concertSeatId(1L).userId(1L)
+          .status(ReservationStatus.WAITING).build();
 
       // when
       reservation.validateConfirmConditions(1L);

--- a/src/test/java/com/example/hhplus/concert/domain/payment/dto/PaymentCommandTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/payment/dto/PaymentCommandTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.example.hhplus.concert.domain.payment.dto.PaymentCommand.CreatePaymentCommand;
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,12 +26,12 @@ class PaymentCommandTest {
       final Integer amount = 1000;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreatePaymentCommand(reservationId, userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.Concert.RESERVATION_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -42,12 +43,11 @@ class PaymentCommandTest {
       final Integer amount = 1000;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreatePaymentCommand(reservationId, userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -59,12 +59,11 @@ class PaymentCommandTest {
       final Integer amount = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreatePaymentCommand(reservationId, userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -76,11 +75,10 @@ class PaymentCommandTest {
       final Integer amount = -1;
 
       // when & then
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreatePaymentCommand(reservationId, userId, amount));
 
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -92,12 +90,11 @@ class PaymentCommandTest {
       final Integer amount = 0;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreatePaymentCommand(reservationId, userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/payment/dto/PaymentQueryTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/payment/dto/PaymentQueryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.example.hhplus.concert.domain.payment.dto.PaymentQuery.GetPaymentByIdQuery;
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,12 +24,11 @@ class PaymentQueryTest {
       final Long paymentId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new GetPaymentByIdQuery(paymentId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Payment.PAYMENT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.Payment.PAYMENT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/user/dto/UserCommandTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/user/dto/UserCommandTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.user.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.user.dto.UserCommand.ChargeUserWalletAmountByWalletIdCommand;
 import com.example.hhplus.concert.domain.user.dto.UserCommand.WithdrawUserWalletAmountCommand;
@@ -25,12 +26,11 @@ class UserCommandTest {
       final Integer amount = 1000;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ChargeUserWalletAmountByWalletIdCommand(walletId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.WALLET_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.WALLET_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -41,12 +41,11 @@ class UserCommandTest {
       final Integer amount = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ChargeUserWalletAmountByWalletIdCommand(walletId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -57,12 +56,11 @@ class UserCommandTest {
       final Integer amount = -1;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ChargeUserWalletAmountByWalletIdCommand(walletId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -73,12 +71,11 @@ class UserCommandTest {
       final Integer amount = 0;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ChargeUserWalletAmountByWalletIdCommand(walletId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -112,12 +109,11 @@ class UserCommandTest {
       final Integer amount = 1000;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new WithdrawUserWalletAmountCommand(userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -128,12 +124,11 @@ class UserCommandTest {
       final Integer amount = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new WithdrawUserWalletAmountCommand(userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -144,12 +139,11 @@ class UserCommandTest {
       final Integer amount = -1;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new WithdrawUserWalletAmountCommand(userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -160,12 +154,11 @@ class UserCommandTest {
       final Integer amount = 0;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new WithdrawUserWalletAmountCommand(userId, amount));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.AMOUNT_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/user/dto/UserQueryTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/user/dto/UserQueryTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.user.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.user.dto.UserQuery.GetUserByIdQuery;
 import com.example.hhplus.concert.domain.user.dto.UserQuery.GetUserWalletByIdQuery;
@@ -26,11 +27,10 @@ class UserQueryTest {
       final Long id = null;
 
       // when & then
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new GetUserByIdQuery(id));
 
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -59,11 +59,10 @@ class UserQueryTest {
       final Long userId = null;
 
       // when & then
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new GetUserWalletByUserIdQuery(userId));
 
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -92,11 +91,10 @@ class UserQueryTest {
       final Long userId = null;
 
       // when & then
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new GetUserWalletByUserIdWithLockQuery(userId));
 
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.USER_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -126,11 +124,10 @@ class UserQueryTest {
       final Long walletId = null;
 
       // when & then
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new GetUserWalletByIdQuery(walletId));
 
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.User.WALLET_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.WALLET_ID_MUST_NOT_BE_NULL);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/user/model/WalletTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/user/model/WalletTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.user.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.user.UserConstants;
 import org.junit.jupiter.api.DisplayName;
@@ -23,12 +24,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(1000).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.chargeAmount(null);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.INVALID_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.INVALID_AMOUNT);
     }
 
     @Test
@@ -38,12 +39,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(1000).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.chargeAmount(-1);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.INVALID_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.INVALID_AMOUNT);
     }
 
     @Test
@@ -53,12 +54,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(1000).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.chargeAmount(0);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.INVALID_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.INVALID_AMOUNT);
     }
 
     @Test
@@ -68,12 +69,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(0).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.chargeAmount(UserConstants.MAX_WALLET_AMOUNT + 1);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT);
     }
 
     @Test
@@ -102,12 +103,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(1000).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.withdrawAmount(null);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.INVALID_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.INVALID_AMOUNT);
     }
 
     @Test
@@ -117,12 +118,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(1000).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.withdrawAmount(-1);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.INVALID_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.INVALID_AMOUNT);
     }
 
     @Test
@@ -132,12 +133,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(1000).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.withdrawAmount(0);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.INVALID_AMOUNT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.INVALID_AMOUNT);
     }
 
     @Test
@@ -147,12 +148,12 @@ class WalletTest {
       final Wallet wallet = Wallet.builder().amount(1000).build();
 
       // when
-      final Exception result = assertThrows(Exception.class, () -> {
+      final CoreException result = assertThrows(CoreException.class, () -> {
         wallet.withdrawAmount(1001);
       });
 
       // then
-      assertThat(result.getMessage()).isEqualTo(ErrorType.User.NOT_ENOUGH_BALANCE.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.NOT_ENOUGH_BALANCE);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/waitingqueue/dto/WaitingQueueCommandTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/waitingqueue/dto/WaitingQueueCommandTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.waitingqueue.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.waitingqueue.dto.WaitingQueueCommand.ActivateWaitingQueuesCommand;
 import com.example.hhplus.concert.domain.waitingqueue.dto.WaitingQueueCommand.CreateWaitingQueueCommand;
@@ -24,12 +25,11 @@ class WaitingQueueCommandTest {
       final Long concertId = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CreateWaitingQueueCommand(concertId));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -59,12 +59,11 @@ class WaitingQueueCommandTest {
       final Integer availableSlots = 1;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ActivateWaitingQueuesCommand(concertId, availableSlots));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -75,12 +74,12 @@ class WaitingQueueCommandTest {
       final Integer availableSlots = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ActivateWaitingQueuesCommand(concertId, availableSlots));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.AVAILABLE_SLOTS_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.AVAILABLE_SLOTS_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -91,12 +90,12 @@ class WaitingQueueCommandTest {
       final Integer availableSlots = 0;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ActivateWaitingQueuesCommand(concertId, availableSlots));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.AVAILABLE_SLOTS_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.AVAILABLE_SLOTS_MUST_BE_POSITIVE);
     }
 
     @Test
@@ -107,12 +106,12 @@ class WaitingQueueCommandTest {
       final Integer availableSlots = -1;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new ActivateWaitingQueuesCommand(concertId, availableSlots));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.AVAILABLE_SLOTS_MUST_BE_POSITIVE.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.AVAILABLE_SLOTS_MUST_BE_POSITIVE);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/waitingqueue/dto/WaitingQueueQueryTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/waitingqueue/dto/WaitingQueueQueryTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.waitingqueue.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.waitingqueue.dto.WaitingQueueQuery.CountWaitingQueueByConcertIdAndStatusQuery;
 import com.example.hhplus.concert.domain.waitingqueue.dto.WaitingQueueQuery.FindDistinctConcertIdsByStatusQuery;
@@ -32,12 +33,12 @@ class WaitingQueueQueryTest {
         final Long id = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetWaitingQueueByIdQuery(id));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_ID_MUST_NOT_BE_NULL.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_ID_MUST_NOT_BE_NULL);
       }
 
       @Test
@@ -66,12 +67,12 @@ class WaitingQueueQueryTest {
         final String uuid = null;
 
         // when
-        final Exception exception = assertThrows(Exception.class,
+        final CoreException exception = assertThrows(CoreException.class,
             () -> new GetWaitingQueueByUuid(uuid));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY.getMessage());
+        assertThat(exception.getErrorType()).isEqualTo(
+            ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
       }
 
       @Test
@@ -101,12 +102,12 @@ class WaitingQueueQueryTest {
       final String uuid = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new GetWaitingQueuePositionByUuid(uuid));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.WAITING_QUEUE_UUID_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -135,12 +136,12 @@ class WaitingQueueQueryTest {
       final WaitingQueueStatus status = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new FindDistinctConcertIdsByStatusQuery(status));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_STATUS_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.WAITING_QUEUE_STATUS_MUST_NOT_BE_NULL);
     }
 
     @Test
@@ -171,12 +172,11 @@ class WaitingQueueQueryTest {
       final WaitingQueueStatus status = WaitingQueueStatus.WAITING;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CountWaitingQueueByConcertIdAndStatusQuery(concertId, status));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_ID_MUST_NOT_BE_NULL);
     }
 
 
@@ -188,12 +188,12 @@ class WaitingQueueQueryTest {
       final WaitingQueueStatus status = null;
 
       // when
-      final Exception exception = assertThrows(Exception.class,
+      final CoreException exception = assertThrows(CoreException.class,
           () -> new CountWaitingQueueByConcertIdAndStatusQuery(concertId, status));
 
       // then
-      assertThat(exception.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_STATUS_MUST_NOT_BE_NULL.getMessage());
+      assertThat(exception.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.WAITING_QUEUE_STATUS_MUST_NOT_BE_NULL);
     }
 
     @Test

--- a/src/test/java/com/example/hhplus/concert/domain/waitingqueue/model/WaitingQueueTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/waitingqueue/model/WaitingQueueTest.java
@@ -3,6 +3,7 @@ package com.example.hhplus.concert.domain.waitingqueue.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.waitingqueue.WaitingQueueConstants;
 import java.time.LocalDateTime;
@@ -21,64 +22,52 @@ class WaitingQueueTest {
     @DisplayName("대기열 토큰 활성화 실패 - 이미 활성화된 토큰")
     void shouldThrowExceptionWhenActivateAlreadyActivatedToken() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .status(WaitingQueueStatus.PROCESSING)
-          .build();
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+          .status(WaitingQueueStatus.PROCESSING).build();
       final LocalDateTime expiredAt = LocalDateTime.now()
           .plusMinutes(WaitingQueueConstants.WAITING_QUEUE_EXPIRE_MINUTES);
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> waitingQueue.activate(expiredAt));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_ALREADY_ACTIVATED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(
+          ErrorType.WaitingQueue.WAITING_QUEUE_ALREADY_ACTIVATED);
     }
 
     @Test
     @DisplayName("대기열 토큰 활성화 실패 - 만료된 토큰")
     void shouldThrowExceptionWhenActivateExpiredToken() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .status(WaitingQueueStatus.WAITING)
-          .expiredAt(LocalDateTime.now().minusMinutes(1))
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+          .status(WaitingQueueStatus.WAITING).expiredAt(LocalDateTime.now().minusMinutes(1))
           .build();
       final LocalDateTime expiredAt = LocalDateTime.now()
           .plusMinutes(WaitingQueueConstants.WAITING_QUEUE_EXPIRE_MINUTES);
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> waitingQueue.activate(expiredAt));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.INVALID_STATUS.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS);
     }
 
     @Test
     @DisplayName("대기열 토큰 활성화 실패 - 만료 시간이 현재 시간보다 빠름")
     void shouldThrowExceptionWhenActivateExpiredAtIsBeforeNow() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .status(WaitingQueueStatus.WAITING)
-          .build();
-      final LocalDateTime expiredAt = LocalDateTime.now()
-          .minusMinutes(1);
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+          .status(WaitingQueueStatus.WAITING).build();
+      final LocalDateTime expiredAt = LocalDateTime.now().minusMinutes(1);
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> waitingQueue.activate(expiredAt));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.INVALID_EXPIRED_AT.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.INVALID_EXPIRED_AT);
     }
 
 
@@ -86,11 +75,8 @@ class WaitingQueueTest {
     @DisplayName("대기열 토큰 활성화 성공")
     void shouldSuccessfullyActivateToken() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .status(WaitingQueueStatus.WAITING)
-          .build();
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+          .status(WaitingQueueStatus.WAITING).build();
       final LocalDateTime expiredAt = LocalDateTime.now()
           .plusMinutes(WaitingQueueConstants.WAITING_QUEUE_EXPIRE_MINUTES);
 
@@ -112,51 +98,38 @@ class WaitingQueueTest {
     @DisplayName("대기열 만료 검증 실패 - 만료된 토큰")
     void shouldThrowExceptionWhenValidateExpiredToken() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .status(WaitingQueueStatus.EXPIRED)
-          .build();
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+          .status(WaitingQueueStatus.EXPIRED).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           waitingQueue::validateNotExpired);
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
     }
 
     @Test
     @DisplayName("대기열 만료 검증 실패 - 만료 시간이 현재 시간보다 늦음")
     void shouldThrowExceptionWhenValidateExpiredAtIsAfterNow() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .status(WaitingQueueStatus.PROCESSING)
-          .expiredAt(LocalDateTime.now())
-          .build();
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+          .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now()).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           waitingQueue::validateNotExpired);
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
     }
 
     @Test
     @DisplayName("대기열 만료 검증 성공")
     void shouldSuccessfullyValidateNotExpired() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .status(WaitingQueueStatus.WAITING)
-          .expiredAt(LocalDateTime.now().plusMinutes(1))
-          .build();
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+          .status(WaitingQueueStatus.WAITING).expiredAt(LocalDateTime.now().plusMinutes(1)).build();
 
       // when
       waitingQueue.validateNotExpired();
@@ -179,11 +152,8 @@ class WaitingQueueTest {
       @DisplayName("대기열 활성 여부 확인 false - 대기열 상태가 활성 상태가 아님")
       void shouldReturnFalseWhenStatusIsNotProcessing() {
         // given
-        final var waitingQueue = WaitingQueue.builder()
-            .uuid("uuid")
-            .concertId(1L)
-            .status(WaitingQueueStatus.WAITING)
-            .build();
+        final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+            .status(WaitingQueueStatus.WAITING).build();
 
         // when
         final boolean result = waitingQueue.isProcessing();
@@ -196,12 +166,8 @@ class WaitingQueueTest {
       @DisplayName("대기열 활성 여부 확인 false - 만료 시간이 현재 시간보다 빠름")
       void shouldReturnFalseWhenExpiredAtIsBeforeNow() {
         // given
-        final var waitingQueue = WaitingQueue.builder()
-            .uuid("uuid")
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now())
-            .build();
+        final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+            .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now()).build();
 
         // when
         final boolean result = waitingQueue.isProcessing();
@@ -214,11 +180,8 @@ class WaitingQueueTest {
       @DisplayName("대기열 활성 여부 확인 true - 대기열 상태가 활성 상태이고 만료 시간이 현재 시간보다 늦음")
       void shouldReturnTrueWhenStatusIsProcessingAndExpiredAtIsAfterNow() {
         // given
-        final var waitingQueue = WaitingQueue.builder()
-            .uuid("uuid")
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
+        final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+            .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
             .build();
 
         // when
@@ -237,50 +200,38 @@ class WaitingQueueTest {
       @DisplayName("대기열 활성 여부 확인 실패 - 대기열 상태가 활성 상태가 아님")
       void shouldThrowExceptionWhenStatusIsNotProcessing() {
         // given
-        final var waitingQueue = WaitingQueue.builder()
-            .uuid("uuid")
-            .concertId(1L)
-            .status(WaitingQueueStatus.WAITING)
-            .build();
+        final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+            .status(WaitingQueueStatus.WAITING).build();
 
         // when
-        final Exception result = assertThrows(Exception.class,
+        final CoreException result = assertThrows(CoreException.class,
             waitingQueue::validateProcessing);
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.INVALID_STATUS.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.INVALID_STATUS);
       }
 
       @Test
       @DisplayName("대기열 활성 여부 확인 실패 - 만료 시간이 현재 시간보다 빠름")
       void shouldThrowExceptionWhenExpiredAtIsBeforeNow() {
         // given
-        final var waitingQueue = WaitingQueue.builder()
-            .uuid("uuid")
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now())
-            .build();
+        final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+            .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now()).build();
 
         // when
-        final Exception result = assertThrows(Exception.class,
+        final CoreException result = assertThrows(CoreException.class,
             waitingQueue::validateProcessing);
 
         // then
-        assertThat(result.getMessage()).isEqualTo(
-            ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED.getMessage());
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
       }
 
       @Test
       @DisplayName("대기열 활성 여부 확인 성공 - 대기열 상태가 활성 상태이고 만료 시간이 현재 시간보다 늦음")
       void shouldSuccessfullyValidateProcessing() {
         // given
-        final var waitingQueue = WaitingQueue.builder()
-            .uuid("uuid")
-            .concertId(1L)
-            .status(WaitingQueueStatus.PROCESSING)
-            .expiredAt(LocalDateTime.now().plusMinutes(1))
+        final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L)
+            .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
             .build();
 
         // when
@@ -301,28 +252,21 @@ class WaitingQueueTest {
     @DisplayName("대기열 콘서트 ID 검증 실패 - 콘서트 ID가 일치하지 않음")
     void shouldThrowExceptionWhenConcertIdIsNotMatched() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .build();
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L).build();
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> waitingQueue.validateConcertId(2L));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.Concert.INVALID_CONCERT_ID.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.INVALID_CONCERT_ID);
     }
 
     @Test
     @DisplayName("대기열 콘서트 ID 검증 성공 - 콘서트 ID가 일치함")
     void shouldSuccessfullyValidateConcertId() {
       // given
-      final var waitingQueue = WaitingQueue.builder()
-          .uuid("uuid")
-          .concertId(1L)
-          .build();
+      final var waitingQueue = WaitingQueue.builder().uuid("uuid").concertId(1L).build();
 
       // when
       waitingQueue.validateConcertId(1L);

--- a/src/test/java/com/example/hhplus/concert/domain/waitingqueue/service/WaitingQueueQueryServiceTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/waitingqueue/service/WaitingQueueQueryServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 
+import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType;
 import com.example.hhplus.concert.domain.waitingqueue.WaitingQueueRepository;
 import com.example.hhplus.concert.domain.waitingqueue.dto.WaitingQueueQuery.GetWaitingQueuePositionByUuid;
@@ -41,17 +42,15 @@ class WaitingQueueQueryServiceTest {
       // given
       final String uuid = "uuid";
       final GetWaitingQueuePositionByUuid query = new GetWaitingQueuePositionByUuid(uuid);
-      doReturn(WaitingQueue.builder().status(WaitingQueueStatus.EXPIRED).build())
-          .when(waitingQueueReader)
-          .getWaitingQueue(new GetWaitingQueueByUuidWithLockParam(uuid));
+      doReturn(WaitingQueue.builder().status(WaitingQueueStatus.EXPIRED).build()).when(
+          waitingQueueReader).getWaitingQueue(new GetWaitingQueueByUuidWithLockParam(uuid));
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> target.getWaitingQueuePosition(query));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
     }
 
     @Test
@@ -61,17 +60,15 @@ class WaitingQueueQueryServiceTest {
       final String uuid = "uuid";
       final GetWaitingQueuePositionByUuid query = new GetWaitingQueuePositionByUuid(uuid);
       doReturn(WaitingQueue.builder().status(WaitingQueueStatus.PROCESSING)
-          .expiredAt(LocalDateTime.now()).build())
-          .when(waitingQueueReader)
+          .expiredAt(LocalDateTime.now()).build()).when(waitingQueueReader)
           .getWaitingQueue(new GetWaitingQueueByUuidWithLockParam(uuid));
 
       // when
-      final Exception result = assertThrows(Exception.class,
+      final CoreException result = assertThrows(CoreException.class,
           () -> target.getWaitingQueuePosition(query));
 
       // then
-      assertThat(result.getMessage()).isEqualTo(
-          ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED.getMessage());
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.WaitingQueue.WAITING_QUEUE_EXPIRED);
     }
 
     @Test
@@ -83,10 +80,8 @@ class WaitingQueueQueryServiceTest {
       final String uuid = "uuid";
       final GetWaitingQueuePositionByUuid query = new GetWaitingQueuePositionByUuid(uuid);
       doReturn(WaitingQueue.builder().id(waitingQueueId).concertId(concertId).uuid(uuid)
-          .status(WaitingQueueStatus.PROCESSING)
-          .expiredAt(LocalDateTime.now().plusMinutes(1))
-          .build())
-          .when(waitingQueueReader)
+          .status(WaitingQueueStatus.PROCESSING).expiredAt(LocalDateTime.now().plusMinutes(1))
+          .build()).when(waitingQueueReader)
           .getWaitingQueue(new GetWaitingQueueByUuidWithLockParam(uuid));
 
       // when
@@ -109,13 +104,10 @@ class WaitingQueueQueryServiceTest {
       final String uuid = "uuid";
       final GetWaitingQueuePositionByUuid query = new GetWaitingQueuePositionByUuid(uuid);
       doReturn(WaitingQueue.builder().id(waitingQueueId).concertId(concertId).uuid(uuid)
-          .status(WaitingQueueStatus.WAITING).build())
-          .when(waitingQueueReader)
+          .status(WaitingQueueStatus.WAITING).build()).when(waitingQueueReader)
           .getWaitingQueue(new GetWaitingQueueByUuidWithLockParam(uuid));
-      doReturn(1)
-          .when(waitingQueueReader)
-          .getWaitingQueuePosition(
-              new GetWaitingQueuePositionByIdAndConcertIdParam(waitingQueueId, concertId));
+      doReturn(1).when(waitingQueueReader).getWaitingQueuePosition(
+          new GetWaitingQueuePositionByIdAndConcertIdParam(waitingQueueId, concertId));
 
       // when
       final var result = target.getWaitingQueuePosition(query);


### PR DESCRIPTION
# 작업 내용

기존 test code를 Exception으로 받아와 error message만 비교하던 방식은 동일한 error message의 exception이 생길때 이슈가 될 것으로 보여 타입을 더 구체화하고 ErrorType으로 비교하는 방식으로 변경했습니다.