### PR TITLE
Step 12: 동시성 제어 고도화 (비관적락, 낙관적락, 분산락)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,15 @@ dependencies {
     runtimeOnly("com.h2database:h2")
 
     annotationProcessor("org.projectlombok:lombok")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    testCompileOnly("org.projectlombok:lombok")
+
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    testAnnotationProcessor("org.projectlombok:lombok")
+
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
     implementation("org.springframework.retry:spring-retry")
+    implementation("org.redisson:redisson-spring-boot-starter:3.37.0")
 
     compileOnly("org.projectlombok:lombok")
 

--- a/src/main/java/com/example/hhplus/concert/application/ConcertFacade.java
+++ b/src/main/java/com/example/hhplus/concert/application/ConcertFacade.java
@@ -73,9 +73,6 @@ public class ConcertFacade {
         new FindReservableConcertSeatsQuery(concertScheduleId));
   }
 
-  /*
-   * @deprecated Pessimistic Locking을 사용한 예약 기능은 성능 이슈가 있어서 사용하지 않습니다.
-   */
   @Deprecated(forRemoval = false)
   public Reservation reserveConcertSeatWithPessimisticLock(Long concertSeatId, Long userId) {
     var user = userQueryService.getUser(new GetUserByIdQuery(userId));
@@ -117,6 +114,7 @@ public class ConcertFacade {
     return concertQueryService.getReservation(new GetReservationByIdQuery(reservationId));
   }
 
+  @Deprecated(forRemoval = false)
   @DistributedLock(type = DistributedLockType.CONCERT_SEAT, keys = "concertSeatId")
   public Reservation reserveConcertSeatWithDistributedLock(Long concertSeatId, Long userId) {
     var user = userQueryService.getUser(new GetUserByIdQuery(userId));
@@ -138,6 +136,7 @@ public class ConcertFacade {
     return concertQueryService.getReservation(new GetReservationByIdQuery(reservationId));
   }
 
+  @Deprecated(forRemoval = false)
   @Transactional
   public Payment payReservation(Long reservationId, Long userId) {
     var reservation = concertQueryService.getReservation(
@@ -165,6 +164,7 @@ public class ConcertFacade {
     return paymentQueryService.getPayment(new GetPaymentByIdQuery(paymentId));
   }
 
+  @Deprecated(forRemoval = false)
   @Retryable(
       retryFor = RuntimeException.class,
       noRetryFor = CoreException.class,

--- a/src/main/java/com/example/hhplus/concert/application/UserFacade.java
+++ b/src/main/java/com/example/hhplus/concert/application/UserFacade.java
@@ -1,5 +1,7 @@
 package com.example.hhplus.concert.application;
 
+import com.example.hhplus.concert.domain.support.DistributedLockType;
+import com.example.hhplus.concert.domain.support.annotation.DistributedLock;
 import com.example.hhplus.concert.domain.support.error.CoreException;
 import com.example.hhplus.concert.domain.support.error.ErrorType.User;
 import com.example.hhplus.concert.domain.user.dto.UserCommand.ChargeUserWalletAmountByWalletIdCommand;
@@ -11,6 +13,8 @@ import com.example.hhplus.concert.domain.user.model.Wallet;
 import com.example.hhplus.concert.domain.user.service.UserCommandService;
 import com.example.hhplus.concert.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +41,46 @@ public class UserFacade {
 
     return userQueryService.getWallet(new GetUserWalletByIdQuery(wallet.getId()));
   }
+
+  @Retryable(
+      retryFor = RuntimeException.class,
+      noRetryFor = CoreException.class,
+      backoff = @Backoff(50),
+      maxAttempts = 100
+  )
+  public Wallet chargeUserWalletAmountWithOptimisticLock(Long userId, Long walletId,
+      Integer amount) {
+    var user = userQueryService.getUser(new GetUserByIdQuery(userId));
+
+    var wallet = userQueryService.getWallet(new GetUserWalletByUserIdQuery(user.getId()));
+
+    if (!wallet.getId().equals(walletId)) {
+      throw new CoreException(User.WALLET_NOT_MATCH_USER);
+    }
+
+    userCommandService.chargeUserWalletAmount(
+        new ChargeUserWalletAmountByWalletIdCommand(wallet.getId(), amount));
+
+    return userQueryService.getWallet(new GetUserWalletByIdQuery(wallet.getId()));
+  }
+
+  @DistributedLock(type = DistributedLockType.USER_WALLET, keys = "userId")
+  public Wallet chargeUserWalletAmountWithDistributionLock(Long userId, Long walletId,
+      Integer amount) {
+    var user = userQueryService.getUser(new GetUserByIdQuery(userId));
+
+    var wallet = userQueryService.getWallet(new GetUserWalletByUserIdQuery(user.getId()));
+
+    if (!wallet.getId().equals(walletId)) {
+      throw new CoreException(User.WALLET_NOT_MATCH_USER);
+    }
+
+    userCommandService.chargeUserWalletAmount(
+        new ChargeUserWalletAmountByWalletIdCommand(wallet.getId(), amount));
+
+    return userQueryService.getWallet(new GetUserWalletByIdQuery(wallet.getId()));
+  }
+
 
   public Wallet getWallet(Long userId) {
     var user = userQueryService.getUser(new GetUserByIdQuery(userId));

--- a/src/main/java/com/example/hhplus/concert/application/UserFacade.java
+++ b/src/main/java/com/example/hhplus/concert/application/UserFacade.java
@@ -26,6 +26,7 @@ public class UserFacade {
 
   private final UserCommandService userCommandService;
 
+  @Deprecated(forRemoval = false)
   @Transactional
   public Wallet chargeUserWalletAmount(Long userId, Long walletId, Integer amount) {
     var user = userQueryService.getUser(new GetUserByIdQuery(userId));
@@ -42,6 +43,7 @@ public class UserFacade {
     return userQueryService.getWallet(new GetUserWalletByIdQuery(wallet.getId()));
   }
 
+  @Deprecated(forRemoval = false)
   @Retryable(
       retryFor = RuntimeException.class,
       noRetryFor = CoreException.class,

--- a/src/main/java/com/example/hhplus/concert/domain/support/DistributedLockType.java
+++ b/src/main/java/com/example/hhplus/concert/domain/support/DistributedLockType.java
@@ -1,0 +1,17 @@
+package com.example.hhplus.concert.domain.support;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum DistributedLockType {
+  CONCERT_SEAT("concertSeatLock"),
+  USER_WALLET("userWalletLock"),
+  RESERVATION("reservationLock"),
+  ;
+
+  private final String lockName;
+
+  public String lockName() {
+    return lockName;
+  }
+}

--- a/src/main/java/com/example/hhplus/concert/domain/support/LockManager.java
+++ b/src/main/java/com/example/hhplus/concert/domain/support/LockManager.java
@@ -1,0 +1,9 @@
+package com.example.hhplus.concert.domain.support;
+
+import java.util.function.Supplier;
+
+public interface LockManager {
+
+  Object lock(String lockName, Supplier<Object> operation) throws Throwable;
+
+}

--- a/src/main/java/com/example/hhplus/concert/domain/support/annotation/DistributedLock.java
+++ b/src/main/java/com/example/hhplus/concert/domain/support/annotation/DistributedLock.java
@@ -1,0 +1,17 @@
+package com.example.hhplus.concert.domain.support.annotation;
+
+import com.example.hhplus.concert.domain.support.DistributedLockType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DistributedLock {
+
+  DistributedLockType type();
+
+  String[] keys();
+
+}

--- a/src/main/java/com/example/hhplus/concert/domain/support/aop/DistributedLockAop.java
+++ b/src/main/java/com/example/hhplus/concert/domain/support/aop/DistributedLockAop.java
@@ -1,0 +1,61 @@
+package com.example.hhplus.concert.domain.support.aop;
+
+import com.example.hhplus.concert.domain.support.LockManager;
+import com.example.hhplus.concert.domain.support.annotation.DistributedLock;
+import com.example.hhplus.concert.domain.support.error.CoreException;
+import com.example.hhplus.concert.domain.support.error.ErrorType;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@RequiredArgsConstructor
+public class DistributedLockAop {
+
+  private final LockManager lockManager;
+
+  @Around("@annotation(distributedLock)")
+  public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock)
+      throws Throwable {
+    String dynamicKey = createDynamicKey(joinPoint, distributedLock.keys());
+    String lockName = distributedLock.type().lockName() + ":" + dynamicKey;
+
+    return lockManager.lock(lockName, () -> {
+      try {
+        return joinPoint.proceed();
+      } catch (RuntimeException | Error e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+  }
+
+  private String createDynamicKey(ProceedingJoinPoint joinPoint, String[] keys) {
+    MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+    String[] methodParameterNames = methodSignature.getParameterNames();
+    Object[] methodArgs = joinPoint.getArgs();
+
+    return Arrays.stream(keys)
+        .map(key -> {
+          int indexOfKey = Arrays.asList(methodParameterNames).indexOf(key);
+          if (indexOfKey == -1 || methodArgs[indexOfKey] == null) {
+            throw new CoreException(ErrorType.KEY_NOT_FOUND_OR_NULL);
+          }
+          return methodArgs[indexOfKey].toString();
+        })
+        .collect(Collectors.joining(":"));
+  }
+
+}
+

--- a/src/main/java/com/example/hhplus/concert/domain/support/error/ErrorCode.java
+++ b/src/main/java/com/example/hhplus/concert/domain/support/error/ErrorCode.java
@@ -3,5 +3,5 @@ package com.example.hhplus.concert.domain.support.error;
 public enum ErrorCode {
   NOT_FOUND,
   BAD_REQUEST,
-  ;
+  INTERNAL_SERVER_ERROR,
 }

--- a/src/main/java/com/example/hhplus/concert/domain/support/error/ErrorType.java
+++ b/src/main/java/com/example/hhplus/concert/domain/support/error/ErrorType.java
@@ -9,6 +9,8 @@ import org.springframework.boot.logging.LogLevel;
 @Getter
 public enum ErrorType implements IErrorType {
   INVALID_REQUEST(ErrorCode.BAD_REQUEST, "유효하지 않은 요청입니다.", LogLevel.WARN),
+  FAILED_TO_ACQUIRE_LOCK(ErrorCode.INTERNAL_SERVER_ERROR, "잠금을 얻는 데 실패했습니다.", LogLevel.ERROR),
+  KEY_NOT_FOUND_OR_NULL(ErrorCode.INTERNAL_SERVER_ERROR, "키를 찾을 수 없거나 null입니다.", LogLevel.ERROR),
   ;
 
   private final ErrorCode code;

--- a/src/main/java/com/example/hhplus/concert/domain/user/UserRepository.java
+++ b/src/main/java/com/example/hhplus/concert/domain/user/UserRepository.java
@@ -4,7 +4,8 @@ import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserByI
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByUserIdParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdWithLockParam;
-import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdIdWithLockParam;
+import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdParam;
+import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdWithLockParam;
 import com.example.hhplus.concert.domain.user.model.User;
 import com.example.hhplus.concert.domain.user.model.Wallet;
 
@@ -18,7 +19,10 @@ public interface UserRepository {
 
   Wallet getWallet(GetUserWalletByWalletIdParam param);
 
+  Wallet getWallet(GetUserWalletByWalletUserIdParam param);
+
   Wallet getWallet(GetUserWalletByWalletIdWithLockParam param);
 
-  Wallet getWallet(GetUserWalletByWalletUserIdIdWithLockParam param);
+  Wallet getWallet(GetUserWalletByWalletUserIdWithLockParam param);
+  
 }

--- a/src/main/java/com/example/hhplus/concert/domain/user/dto/UserCommand.java
+++ b/src/main/java/com/example/hhplus/concert/domain/user/dto/UserCommand.java
@@ -20,11 +20,11 @@ public class UserCommand {
     }
   }
 
-  public record WithdrawUserWalletAmountCommand(Long userId, Integer amount) {
+  public record WithdrawUserWalletAmountCommand(Long walletId, Integer amount) {
 
     public WithdrawUserWalletAmountCommand {
-      if (userId == null) {
-        throw new CoreException(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
+      if (walletId == null) {
+        throw new CoreException(ErrorType.User.WALLET_ID_MUST_NOT_BE_NULL);
       }
       if (amount == null) {
         throw new CoreException(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);

--- a/src/main/java/com/example/hhplus/concert/domain/user/dto/UserRepositoryParam.java
+++ b/src/main/java/com/example/hhplus/concert/domain/user/dto/UserRepositoryParam.java
@@ -26,7 +26,13 @@ public class UserRepositoryParam {
 
   }
 
-  public record GetUserWalletByWalletUserIdIdWithLockParam(
+  public record GetUserWalletByWalletUserIdParam(
+      Long userId
+  ) {
+
+  }
+
+  public record GetUserWalletByWalletUserIdWithLockParam(
       Long userId
   ) {
 

--- a/src/main/java/com/example/hhplus/concert/domain/user/model/Wallet.java
+++ b/src/main/java/com/example/hhplus/concert/domain/user/model/Wallet.java
@@ -7,6 +7,7 @@ import com.example.hhplus.concert.domain.user.UserConstants;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +25,9 @@ public class Wallet extends BaseEntity {
 
   @Column(nullable = false)
   private int amount;
+
+  @Version
+  private Long version;
 
   @Builder
   public Wallet(Long id, Long userId, int amount, LocalDateTime createdAt,

--- a/src/main/java/com/example/hhplus/concert/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/hhplus/concert/domain/user/service/UserCommandService.java
@@ -3,7 +3,6 @@ package com.example.hhplus.concert.domain.user.service;
 import com.example.hhplus.concert.domain.user.UserRepository;
 import com.example.hhplus.concert.domain.user.dto.UserCommand.ChargeUserWalletAmountByWalletIdCommand;
 import com.example.hhplus.concert.domain.user.dto.UserCommand.WithdrawUserWalletAmountCommand;
-import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdIdWithLockParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,8 +25,7 @@ public class UserCommandService {
   }
 
   public void withDrawUserWalletAmount(WithdrawUserWalletAmountCommand command) {
-    var wallet = userRepository.getWallet(
-        new GetUserWalletByWalletUserIdIdWithLockParam(command.userId()));
+    var wallet = userRepository.getWallet(new GetUserWalletByWalletIdParam(command.walletId()));
 
     wallet.withdrawAmount(command.amount());
 

--- a/src/main/java/com/example/hhplus/concert/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/hhplus/concert/domain/user/service/UserCommandService.java
@@ -3,8 +3,8 @@ package com.example.hhplus.concert.domain.user.service;
 import com.example.hhplus.concert.domain.user.UserRepository;
 import com.example.hhplus.concert.domain.user.dto.UserCommand.ChargeUserWalletAmountByWalletIdCommand;
 import com.example.hhplus.concert.domain.user.dto.UserCommand.WithdrawUserWalletAmountCommand;
-import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdWithLockParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdIdWithLockParam;
+import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +18,7 @@ public class UserCommandService {
 
   public void chargeUserWalletAmount(ChargeUserWalletAmountByWalletIdCommand command) {
     var wallet = userRepository.getWallet(
-        new GetUserWalletByWalletIdWithLockParam(command.walletId()));
+        new GetUserWalletByWalletIdParam(command.walletId()));
 
     wallet.chargeAmount(command.amount());
 

--- a/src/main/java/com/example/hhplus/concert/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/example/hhplus/concert/domain/user/service/UserQueryService.java
@@ -8,7 +8,7 @@ import com.example.hhplus.concert.domain.user.dto.UserQuery.GetUserWalletByUserI
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserByIdParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByUserIdParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdParam;
-import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdIdWithLockParam;
+import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdWithLockParam;
 import com.example.hhplus.concert.domain.user.model.User;
 import com.example.hhplus.concert.domain.user.model.Wallet;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class UserQueryService {
   }
 
   public Wallet getWallet(GetUserWalletByUserIdWithLockQuery query) {
-    return userRepository.getWallet(new GetUserWalletByWalletUserIdIdWithLockParam(query.userId()));
+    return userRepository.getWallet(new GetUserWalletByWalletUserIdWithLockParam(query.userId()));
   }
 
   public Wallet getWallet(GetUserWalletByIdQuery query) {

--- a/src/main/java/com/example/hhplus/concert/infra/db/user/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/example/hhplus/concert/infra/db/user/impl/UserRepositoryImpl.java
@@ -7,7 +7,8 @@ import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserByI
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByUserIdParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdParam;
 import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletIdWithLockParam;
-import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdIdWithLockParam;
+import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdParam;
+import com.example.hhplus.concert.domain.user.dto.UserRepositoryParam.GetUserWalletByWalletUserIdWithLockParam;
 import com.example.hhplus.concert.domain.user.model.User;
 import com.example.hhplus.concert.domain.user.model.Wallet;
 import com.example.hhplus.concert.infra.db.user.UserJpaRepository;
@@ -47,13 +48,19 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
+  public Wallet getWallet(GetUserWalletByWalletUserIdParam param) {
+    return walletJpaRepository.findByUserId(param.userId())
+        .orElseThrow(() -> new CoreException(ErrorType.User.WALLET_NOT_FOUND));
+  }
+
+  @Override
   public Wallet getWallet(GetUserWalletByWalletIdWithLockParam param) {
     return walletJpaRepository.findByIdWithLock(param.walletId())
         .orElseThrow(() -> new CoreException(ErrorType.User.WALLET_NOT_FOUND));
   }
 
   @Override
-  public Wallet getWallet(GetUserWalletByWalletUserIdIdWithLockParam param) {
+  public Wallet getWallet(GetUserWalletByWalletUserIdWithLockParam param) {
     return walletJpaRepository.findByUserIdWithLock(param.userId())
         .orElseThrow(() -> new CoreException(ErrorType.User.WALLET_NOT_FOUND));
   }

--- a/src/main/java/com/example/hhplus/concert/infra/redis/RedissonConfig.java
+++ b/src/main/java/com/example/hhplus/concert/infra/redis/RedissonConfig.java
@@ -1,0 +1,29 @@
+package com.example.hhplus.concert.infra.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedissonConfig {
+
+  private static final String REDISSON_HOST_PREFIX = "redis://";
+
+  private final RedisProperties redisProperties;
+
+
+  @Bean
+  public RedissonClient redissonClient() {
+    Config config = new Config();
+    config.useSingleServer()
+        .setAddress(
+            REDISSON_HOST_PREFIX + redisProperties.getHost() + ":" + redisProperties.getPort());
+    return Redisson.create(config);
+  }
+
+}

--- a/src/main/java/com/example/hhplus/concert/infra/redis/RedissonLockManager.java
+++ b/src/main/java/com/example/hhplus/concert/infra/redis/RedissonLockManager.java
@@ -1,0 +1,43 @@
+package com.example.hhplus.concert.infra.redis;
+
+import com.example.hhplus.concert.domain.support.LockManager;
+import com.example.hhplus.concert.domain.support.error.CoreException;
+import com.example.hhplus.concert.domain.support.error.ErrorType;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RedissonLockManager implements LockManager {
+
+  private static final long WAIT_TIME = 5L;
+  private static final long LEASE_TIME = 3L;
+  private static final TimeUnit TIME_UNIT = TimeUnit.SECONDS;
+  private final RedissonClient redissonClient;
+
+  @Transactional(propagation = Propagation.NEVER)
+  @Override
+  public Object lock(String lockName, Supplier<Object> operation) throws Throwable {
+    RLock rLock = redissonClient.getLock(lockName);
+
+    try {
+      boolean available = rLock.tryLock(WAIT_TIME, LEASE_TIME, TIME_UNIT);
+
+      if (!available) {
+        throw new CoreException(ErrorType.FAILED_TO_ACQUIRE_LOCK);
+      }
+
+      return operation.get();
+    } catch (InterruptedException e) {
+      throw new InterruptedException();
+    } finally {
+      rLock.unlock();
+    }
+  }
+}

--- a/src/main/java/com/example/hhplus/concert/interfaces/api/controller/impl/ConcertSeatController.java
+++ b/src/main/java/com/example/hhplus/concert/interfaces/api/controller/impl/ConcertSeatController.java
@@ -28,7 +28,7 @@ public class ConcertSeatController implements IConcertSeatController {
       @RequestHeader(CommonHttpHeader.X_WAITING_QUEUE_TOKEN_UUID) String waitingQueueTokenUuid
   ) {
     ReservationResponse reservation = new ReservationResponse(
-        concertFacade.reserveConcertSeatWithPessimisticLock(concertSeatId, userId));
+        concertFacade.reserveConcertSeat(concertSeatId, userId));
 
     return ResponseEntity.status(HttpStatus.CREATED).body(new ReserveSeatResponse(reservation));
   }

--- a/src/main/java/com/example/hhplus/concert/interfaces/api/controller/impl/ReservationController.java
+++ b/src/main/java/com/example/hhplus/concert/interfaces/api/controller/impl/ReservationController.java
@@ -26,7 +26,7 @@ public class ReservationController implements IReservationController {
       @RequestHeader(CommonHttpHeader.X_USER_ID) Long userId
   ) {
     PaymentResponse payment = new PaymentResponse(
-        concertFacade.payReservation(reservationId, userId));
+        concertFacade.payReservationWithDistributedLock(reservationId, userId));
 
     return ResponseEntity.ok(new PayReservationResponse(payment));
   }

--- a/src/main/java/com/example/hhplus/concert/interfaces/api/controller/impl/UserController.java
+++ b/src/main/java/com/example/hhplus/concert/interfaces/api/controller/impl/UserController.java
@@ -33,7 +33,7 @@ public class UserController implements IUserController {
   public ResponseEntity<ChargeWalletAmountResponse> chargeWallet(@PathVariable Long userId,
       @PathVariable Long walletId, @RequestBody ChargeWalletAmountRequest request) {
     WalletResponse wallet = new WalletResponse(
-        userFacade.chargeUserWalletAmount(userId, walletId, request.amount()));
+        userFacade.chargeUserWalletAmountWithDistributionLock(userId, walletId, request.amount()));
 
     return ResponseEntity.ok(new ChargeWalletAmountResponse(wallet));
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
       hibernate:
         format_sql: ${JPA_FORMAT_SQL:false}
         highlight_sql: ${JPA_HIGHLIGHT_SQL:false}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 # Swagger springdoc-ui Configuration
 springdoc:

--- a/src/test/java/com/example/hhplus/concert/application/ConcertFacadeConcurrencyTest.java
+++ b/src/test/java/com/example/hhplus/concert/application/ConcertFacadeConcurrencyTest.java
@@ -299,144 +299,706 @@ class ConcertFacadeConcurrencyTest {
   @DisplayName("콘서트 좌석 예약 내역 결제 동시성 테스트")
   class PayConcertSeatReservationConcurrencyTest {
 
-    @Test
-    @DisplayName("동시성 테스트 - 동일 좌석 동시 결제")
-    void shouldSuccessfullyPayConcertSeatReservation() {
-      // given
-      final int threadCount = 10;
-      ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-          ConcertSchedule.builder()
-              .concertId(1L)
-              .concertAt(LocalDateTime.now().plusDays(1))
-              .reservationStartAt(LocalDateTime.now().minusDays(1))
-              .reservationEndAt(LocalDateTime.now().plusDays(1))
-              .build()
-      );
+    @Nested
+    @DisplayName("콘서트 좌석 예약 내역 결제 동시성 테스트 비관적락")
+    class PayConcertSeatReservationWithPessimisticLock {
 
-      ConcertSeat concertSeat = concertSeatJpaRepository.save(
-          ConcertSeat.builder()
-              .concertScheduleId(concertSchedule.getId())
-              .number(1)
-              .isReserved(true)
-              .price(10000)
-              .build()
-      );
+      @Test
+      @DisplayName("동시성 테스트 - 동일 좌석 동시 결제")
+      void shouldSuccessfullyPayConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
 
-      User user = userJpaRepository.save(User.builder().name("user").build());
+        ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder()
+                .concertScheduleId(concertSchedule.getId())
+                .number(1)
+                .isReserved(true)
+                .price(10000)
+                .build()
+        );
 
-      Wallet userWallet = walletJpaRepository.save(
-          Wallet.builder().userId(user.getId()).amount(10000).build());
+        User user = userJpaRepository.save(User.builder().name("user").build());
 
-      Reservation reservation = reservationJpaRepository.save(
-          Reservation.builder()
-              .concertSeatId(concertSeat.getId())
-              .userId(user.getId())
-              .status(ReservationStatus.WAITING)
-              .reservedAt(LocalDateTime.now())
-              .build()
-      );
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(10000).build());
 
-      // when
-      final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
-          .mapToObj(i -> CompletableFuture.runAsync(() -> {
-            try {
-              concertFacade.payReservation(reservation.getId(), user.getId());
-            } catch (CoreException e) {
-              if (e.getErrorType().equals(ErrorType.Concert.RESERVATION_ALREADY_PAID)) {
-                return;
+        Reservation reservation = reservationJpaRepository.save(
+            Reservation.builder()
+                .concertSeatId(concertSeat.getId())
+                .userId(user.getId())
+                .status(ReservationStatus.WAITING)
+                .reservedAt(LocalDateTime.now())
+                .build()
+        );
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservation(reservation.getId(), user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.Concert.RESERVATION_ALREADY_PAID)) {
+                  return;
+                }
+
+                throw e;
               }
+            }))
+            .toList();
 
-              throw e;
-            }
-          }))
-          .toList();
+        long start = System.currentTimeMillis();
 
-      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
-      // then
-      final Reservation updatedReservation = reservationJpaRepository.findById(reservation.getId())
-          .get();
+        long end = System.currentTimeMillis();
 
-      assertThat(updatedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+        log.info("비관적 락 Execution Time: " + (end - start) + "ms");
 
-      final List<Payment> payments = paymentJpaRepository.findAll();
-      assertThat(payments).hasSize(1);
+        // then
+        final Reservation updatedReservation = reservationJpaRepository.findById(
+                reservation.getId())
+            .get();
 
-      final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
-      assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+        assertThat(updatedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+        final List<Payment> payments = paymentJpaRepository.findAll();
+        assertThat(payments).hasSize(1);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
+
+      @Test
+      @DisplayName("동시성 테스트 - 다른 좌석 같은 사용자 동시 결제 잔액 부족")
+      void shouldThrowExceptionWhenPayConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        final int canPayCount = 5;
+        final int perSeatPrice = 10000;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        List<ConcertSeat> concertSeats = IntStream.range(0, threadCount)
+            .mapToObj(i -> concertSeatJpaRepository.save(
+                ConcertSeat.builder()
+                    .concertScheduleId(concertSchedule.getId())
+                    .number(i)
+                    .isReserved(true)
+                    .price(perSeatPrice)
+                    .build()
+            ))
+            .toList();
+
+        User user = userJpaRepository.save(User.builder().name("user").build());
+
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(perSeatPrice * canPayCount).build());
+
+        List<Reservation> reservations = concertSeats.stream()
+            .map(concertSeat -> reservationJpaRepository.save(
+                Reservation.builder()
+                    .concertSeatId(concertSeat.getId())
+                    .userId(user.getId())
+                    .status(ReservationStatus.WAITING)
+                    .reservedAt(LocalDateTime.now())
+                    .build()
+            ))
+            .toList();
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservation(reservations.get(i).getId(), user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.User.NOT_ENOUGH_BALANCE)) {
+                  return;
+                }
+
+                throw e;
+              }
+            }))
+            .toList();
+
+        long start = System.currentTimeMillis();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+
+        log.info("비관적 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final List<Reservation> updatedReservations = reservationJpaRepository.findAll();
+        final int paidCount = (int) updatedReservations.stream()
+            .filter(reservation -> reservation.getStatus().equals(ReservationStatus.CONFIRMED))
+            .count();
+        assertThat(paidCount).isEqualTo(canPayCount);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
+
+      @Test
+      @DisplayName("동시성 테스트 - 다른 좌석 같은 사용자 동시 결제")
+      void shouldSuccessfullyPayOtherConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        final int perSeatPrice = 10000;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        List<ConcertSeat> concertSeats = IntStream.range(0, threadCount)
+            .mapToObj(i -> concertSeatJpaRepository.save(
+                ConcertSeat.builder()
+                    .concertScheduleId(concertSchedule.getId())
+                    .number(i)
+                    .isReserved(true)
+                    .price(perSeatPrice)
+                    .build()
+            ))
+            .toList();
+
+        User user = userJpaRepository.save(User.builder().name("user").build());
+
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(perSeatPrice * threadCount).build());
+
+        List<Reservation> reservations = concertSeats.stream()
+            .map(concertSeat -> reservationJpaRepository.save(
+                Reservation.builder()
+                    .concertSeatId(concertSeat.getId())
+                    .userId(user.getId())
+                    .status(ReservationStatus.WAITING)
+                    .reservedAt(LocalDateTime.now())
+                    .build()
+            ))
+            .toList();
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservation(reservations.get(i).getId(), user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.User.NOT_ENOUGH_BALANCE)) {
+                  return;
+                }
+
+                throw e;
+              }
+            }))
+            .toList();
+
+        long start = System.currentTimeMillis();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+
+        log.info("비관적 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final List<Reservation> updatedReservations = reservationJpaRepository.findAll();
+        final int paidCount = (int) updatedReservations.stream()
+            .filter(reservation -> reservation.getStatus().equals(ReservationStatus.CONFIRMED))
+            .count();
+        assertThat(paidCount).isEqualTo(threadCount);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
     }
 
-    @Test
-    @DisplayName("동시성 테스트 - 다른 좌석 같은 사용자 동시 결제 잔액 부족")
-    void shouldThrowExceptionWhenPayConcertSeatReservation() {
-      // given
-      final int threadCount = 10;
-      final int canPayCount = 5;
-      final int perSeatPrice = 10000;
-      ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
-          ConcertSchedule.builder()
-              .concertId(1L)
-              .concertAt(LocalDateTime.now().plusDays(1))
-              .reservationStartAt(LocalDateTime.now().minusDays(1))
-              .reservationEndAt(LocalDateTime.now().plusDays(1))
-              .build()
-      );
+    @Nested
+    @DisplayName("콘서트 좌석 예약 내역 결제 동시성 테스트 낙관적락")
+    class PayConcertSeatReservationWithOptimisticLock {
 
-      List<ConcertSeat> concertSeats = IntStream.range(0, threadCount)
-          .mapToObj(i -> concertSeatJpaRepository.save(
-              ConcertSeat.builder()
-                  .concertScheduleId(concertSchedule.getId())
-                  .number(i)
-                  .isReserved(true)
-                  .price(perSeatPrice)
-                  .build()
-          ))
-          .toList();
+      @Test
+      @DisplayName("동시성 테스트 - 동일 좌석 동시 결제")
+      void shouldSuccessfullyPayConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
 
-      User user = userJpaRepository.save(User.builder().name("user").build());
+        ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder()
+                .concertScheduleId(concertSchedule.getId())
+                .number(1)
+                .isReserved(true)
+                .price(10000)
+                .build()
+        );
 
-      Wallet userWallet = walletJpaRepository.save(
-          Wallet.builder().userId(user.getId()).amount(perSeatPrice * canPayCount).build());
+        User user = userJpaRepository.save(User.builder().name("user").build());
 
-      List<Reservation> reservations = concertSeats.stream()
-          .map(concertSeat -> reservationJpaRepository.save(
-              Reservation.builder()
-                  .concertSeatId(concertSeat.getId())
-                  .userId(user.getId())
-                  .status(ReservationStatus.WAITING)
-                  .reservedAt(LocalDateTime.now())
-                  .build()
-          ))
-          .toList();
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(10000).build());
 
-      // when
-      final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
-          .mapToObj(i -> CompletableFuture.runAsync(() -> {
-            try {
-              concertFacade.payReservation(reservations.get(i).getId(), user.getId());
-            } catch (CoreException e) {
-              if (e.getErrorType().equals(ErrorType.User.NOT_ENOUGH_BALANCE)) {
-                return;
+        Reservation reservation = reservationJpaRepository.save(
+            Reservation.builder()
+                .concertSeatId(concertSeat.getId())
+                .userId(user.getId())
+                .status(ReservationStatus.WAITING)
+                .reservedAt(LocalDateTime.now())
+                .build()
+        );
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservationWithOptimisticLock(reservation.getId(), user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.Concert.RESERVATION_ALREADY_PAID)) {
+                  return;
+                }
+
+                throw e;
               }
+            }))
+            .toList();
 
-              throw e;
-            }
-          }))
-          .toList();
+        long start = System.currentTimeMillis();
 
-      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
-      // then
-      final List<Reservation> updatedReservations = reservationJpaRepository.findAll();
-      final int paidCount = (int) updatedReservations.stream()
-          .filter(reservation -> reservation.getStatus().equals(ReservationStatus.CONFIRMED))
-          .count();
-      assertThat(paidCount).isEqualTo(canPayCount);
+        long end = System.currentTimeMillis();
 
-      final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
-      assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+        log.info("낙관적 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final Reservation updatedReservation = reservationJpaRepository.findById(
+                reservation.getId())
+            .get();
+
+        assertThat(updatedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+        final List<Payment> payments = paymentJpaRepository.findAll();
+        assertThat(payments).hasSize(1);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
+
+      @Test
+      @DisplayName("동시성 테스트 - 다른 좌석 같은 사용자 동시 결제 잔액 부족")
+      void shouldThrowExceptionWhenPayConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        final int canPayCount = 5;
+        final int perSeatPrice = 10000;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        List<ConcertSeat> concertSeats = IntStream.range(0, threadCount)
+            .mapToObj(i -> concertSeatJpaRepository.save(
+                ConcertSeat.builder()
+                    .concertScheduleId(concertSchedule.getId())
+                    .number(i)
+                    .isReserved(true)
+                    .price(perSeatPrice)
+                    .build()
+            ))
+            .toList();
+
+        User user = userJpaRepository.save(User.builder().name("user").build());
+
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(perSeatPrice * canPayCount).build());
+
+        List<Reservation> reservations = concertSeats.stream()
+            .map(concertSeat -> reservationJpaRepository.save(
+                Reservation.builder()
+                    .concertSeatId(concertSeat.getId())
+                    .userId(user.getId())
+                    .status(ReservationStatus.WAITING)
+                    .reservedAt(LocalDateTime.now())
+                    .build()
+            ))
+            .toList();
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservationWithOptimisticLock(reservations.get(i).getId(),
+                    user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.User.NOT_ENOUGH_BALANCE)) {
+                  return;
+                }
+
+                throw e;
+              }
+            }))
+            .toList();
+
+        long start = System.currentTimeMillis();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+
+        log.info("낙관적 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final List<Reservation> updatedReservations = reservationJpaRepository.findAll();
+        final int paidCount = (int) updatedReservations.stream()
+            .filter(reservation -> reservation.getStatus().equals(ReservationStatus.CONFIRMED))
+            .count();
+        assertThat(paidCount).isEqualTo(canPayCount);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
+
+      @Test
+      @DisplayName("동시성 테스트 - 다른 좌석 같은 사용자 동시 결제")
+      void shouldSuccessfullyPayOtherConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        final int perSeatPrice = 10000;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        List<ConcertSeat> concertSeats = IntStream.range(0, threadCount)
+            .mapToObj(i -> concertSeatJpaRepository.save(
+                ConcertSeat.builder()
+                    .concertScheduleId(concertSchedule.getId())
+                    .number(i)
+                    .isReserved(true)
+                    .price(perSeatPrice)
+                    .build()
+            ))
+            .toList();
+
+        User user = userJpaRepository.save(User.builder().name("user").build());
+
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(perSeatPrice * threadCount).build());
+
+        List<Reservation> reservations = concertSeats.stream()
+            .map(concertSeat -> reservationJpaRepository.save(
+                Reservation.builder()
+                    .concertSeatId(concertSeat.getId())
+                    .userId(user.getId())
+                    .status(ReservationStatus.WAITING)
+                    .reservedAt(LocalDateTime.now())
+                    .build()
+            ))
+            .toList();
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservationWithOptimisticLock(reservations.get(i).getId(),
+                    user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.User.NOT_ENOUGH_BALANCE)) {
+                  return;
+                }
+
+                throw e;
+              }
+            }))
+            .toList();
+
+        long start = System.currentTimeMillis();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+
+        log.info("낙관적 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final List<Reservation> updatedReservations = reservationJpaRepository.findAll();
+        final int paidCount = (int) updatedReservations.stream()
+            .filter(reservation -> reservation.getStatus().equals(ReservationStatus.CONFIRMED))
+            .count();
+        assertThat(paidCount).isEqualTo(threadCount);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
     }
+
+    @Nested
+    @DisplayName("콘서트 좌석 예약 내역 결제 동시성 테스트 분산락")
+    class PayConcertSeatReservationWithDistributedLock {
+
+      @Test
+      @DisplayName("동시성 테스트 - 동일 좌석 동시 결제")
+      void shouldSuccessfullyPayConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder()
+                .concertScheduleId(concertSchedule.getId())
+                .number(1)
+                .isReserved(true)
+                .price(10000)
+                .build()
+        );
+
+        User user = userJpaRepository.save(User.builder().name("user").build());
+
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(10000).build());
+
+        Reservation reservation = reservationJpaRepository.save(
+            Reservation.builder()
+                .concertSeatId(concertSeat.getId())
+                .userId(user.getId())
+                .status(ReservationStatus.WAITING)
+                .reservedAt(LocalDateTime.now())
+                .build()
+        );
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservationWithDistributedLock(reservation.getId(), user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.Concert.RESERVATION_ALREADY_PAID)) {
+                  return;
+                }
+
+                throw e;
+              }
+            }))
+            .toList();
+
+        long start = System.currentTimeMillis();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+
+        log.info("분산 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final Reservation updatedReservation = reservationJpaRepository.findById(
+                reservation.getId())
+            .get();
+
+        assertThat(updatedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+        final List<Payment> payments = paymentJpaRepository.findAll();
+        assertThat(payments).hasSize(1);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
+
+      @Test
+      @DisplayName("동시성 테스트 - 다른 좌석 같은 사용자 동시 결제 잔액 부족")
+      void shouldThrowExceptionWhenPayConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        final int canPayCount = 5;
+        final int perSeatPrice = 10000;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        List<ConcertSeat> concertSeats = IntStream.range(0, threadCount)
+            .mapToObj(i -> concertSeatJpaRepository.save(
+                ConcertSeat.builder()
+                    .concertScheduleId(concertSchedule.getId())
+                    .number(i)
+                    .isReserved(true)
+                    .price(perSeatPrice)
+                    .build()
+            ))
+            .toList();
+
+        User user = userJpaRepository.save(User.builder().name("user").build());
+
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(perSeatPrice * canPayCount).build());
+
+        List<Reservation> reservations = concertSeats.stream()
+            .map(concertSeat -> reservationJpaRepository.save(
+                Reservation.builder()
+                    .concertSeatId(concertSeat.getId())
+                    .userId(user.getId())
+                    .status(ReservationStatus.WAITING)
+                    .reservedAt(LocalDateTime.now())
+                    .build()
+            ))
+            .toList();
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservationWithDistributedLock(reservations.get(i).getId(),
+                    user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.User.NOT_ENOUGH_BALANCE)) {
+                  return;
+                }
+
+                throw e;
+              }
+            }))
+            .toList();
+
+        long start = System.currentTimeMillis();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+
+        log.info("분산 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final List<Reservation> updatedReservations = reservationJpaRepository.findAll();
+        final int paidCount = (int) updatedReservations.stream()
+            .filter(reservation -> reservation.getStatus().equals(ReservationStatus.CONFIRMED))
+            .count();
+        assertThat(paidCount).isEqualTo(canPayCount);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
+
+      @Test
+      @DisplayName("동시성 테스트 - 다른 좌석 같은 사용자 동시 결제")
+      void shouldSuccessfullyPayOtherConcertSeatReservation() {
+        // given
+        final int threadCount = 100;
+        final int perSeatPrice = 10000;
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder()
+                .concertId(1L)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().minusDays(1))
+                .reservationEndAt(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        List<ConcertSeat> concertSeats = IntStream.range(0, threadCount)
+            .mapToObj(i -> concertSeatJpaRepository.save(
+                ConcertSeat.builder()
+                    .concertScheduleId(concertSchedule.getId())
+                    .number(i)
+                    .isReserved(true)
+                    .price(perSeatPrice)
+                    .build()
+            ))
+            .toList();
+
+        User user = userJpaRepository.save(User.builder().name("user").build());
+
+        Wallet userWallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(perSeatPrice * threadCount).build());
+
+        List<Reservation> reservations = concertSeats.stream()
+            .map(concertSeat -> reservationJpaRepository.save(
+                Reservation.builder()
+                    .concertSeatId(concertSeat.getId())
+                    .userId(user.getId())
+                    .status(ReservationStatus.WAITING)
+                    .reservedAt(LocalDateTime.now())
+                    .build()
+            ))
+            .toList();
+
+        // when
+        final List<CompletableFuture<Void>> futures = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+              try {
+                concertFacade.payReservationWithDistributedLock(reservations.get(i).getId(),
+                    user.getId());
+              } catch (CoreException e) {
+                if (e.getErrorType().equals(ErrorType.User.NOT_ENOUGH_BALANCE)) {
+                  return;
+                }
+
+                throw e;
+              }
+            }))
+            .toList();
+
+        long start = System.currentTimeMillis();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+
+        log.info("분산락 락 Execution Time: " + (end - start) + "ms");
+
+        // then
+        final List<Reservation> updatedReservations = reservationJpaRepository.findAll();
+        final int paidCount = (int) updatedReservations.stream()
+            .filter(reservation -> reservation.getStatus().equals(ReservationStatus.CONFIRMED))
+            .count();
+        assertThat(paidCount).isEqualTo(threadCount);
+
+        final Wallet updatedUserWallet = walletJpaRepository.findById(userWallet.getId()).get();
+        assertThat(updatedUserWallet.getAmount()).isEqualTo(0);
+      }
+    }
+
   }
-
 
 }

--- a/src/test/java/com/example/hhplus/concert/application/ConcertFacadeTest.java
+++ b/src/test/java/com/example/hhplus/concert/application/ConcertFacadeTest.java
@@ -627,6 +627,181 @@ class ConcertFacadeTest {
       }
 
     }
+
+    @Nested
+    @DisplayName("콘서트 좌석 예약 분산락 락 테스트")
+    class ReserveConcertSeatWithDistributedLockTest {
+
+      @Test
+      @DisplayName("콘서트 좌석 예약 실패 - 좌석 ID가 null")
+      void shouldThrowConcertSeatIdMustNotBeNullException() {
+        // given
+        final Long concertSeatId = null;
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+
+        // when
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          concertFacade.reserveConcertSeatWithDistributedLock(concertSeatId, userId);
+        });
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.KEY_NOT_FOUND_OR_NULL);
+      }
+
+      @Test
+      @DisplayName("콘서트 좌석 예약 실패 - 사용자 ID가 null")
+      void shouldThrowUserIdMustNotBeNullException() {
+        // given
+        final Long concertSeatId = 1L;
+        final Long userId = null;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          concertFacade.reserveConcertSeatWithDistributedLock(concertSeatId, userId);
+        });
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
+      }
+
+      @Test
+      @DisplayName("콘서트 좌석 예약 실패 - 사용자가 존재하지 않음")
+      void shouldThrowUserNotFoundException() {
+        // given
+        final Long concertSeatId = 1L;
+        final Long userId = 1L;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          concertFacade.reserveConcertSeatWithDistributedLock(concertSeatId, userId);
+        });
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
+      }
+
+      @Test
+      @DisplayName("콘서트 좌석 예약 실패 - 좌석이 존재하지 않음")
+      void shouldThrowConcertSeatNotFoundException() {
+        // given
+        final Long concertSeatId = 1L;
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+
+        // when
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          concertFacade.reserveConcertSeatWithDistributedLock(concertSeatId, userId);
+        });
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.Concert.CONCERT_SEAT_NOT_FOUND);
+      }
+
+      @Test
+      @DisplayName("콘서트 좌석 예약 실패 - 예약 가능한 시간이 아님")
+      void shouldThrowReservationTimeException() {
+        // given
+        final Concert concert = concertJpaRepository.save(
+            Concert.builder().title("title").description("description").build());
+        final Long concertId = concert.getId();
+
+        final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder().concertId(concertId)
+                .concertAt(LocalDateTime.now().plusDays(1))
+                .reservationStartAt(LocalDateTime.now().plusMinutes(1))
+                .reservationEndAt(LocalDateTime.now().plusMinutes(2)).build());
+        final Long concertScheduleId = concertSchedule.getId();
+
+        final ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder().concertScheduleId(concertScheduleId).number(1).price(100)
+                .isReserved(false).build());
+        final Long concertSeatId = concertSeat.getId();
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+
+        // when
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          concertFacade.reserveConcertSeatWithDistributedLock(concertSeatId, userId);
+        });
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SCHEDULE_NOT_RESERVABLE);
+      }
+
+      @Test
+      @DisplayName("콘서트 좌석 예약 실패 - 좌석이 이미 예약됨")
+      void shouldThrowConcertSeatAlreadyReservedException() {
+        // given
+        final Concert concert = concertJpaRepository.save(
+            Concert.builder().title("title").description("description").build());
+        final Long concertId = concert.getId();
+
+        final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder().concertId(concertId)
+                .concertAt(LocalDateTime.now().plusDays(1)).reservationStartAt(LocalDateTime.now())
+                .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
+        final Long concertScheduleId = concertSchedule.getId();
+
+        final ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder().concertScheduleId(concertScheduleId).number(1).price(100)
+                .isReserved(true).build());
+        final Long concertSeatId = concertSeat.getId();
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+
+        // when
+        final CoreException result = assertThrows(CoreException.class, () -> {
+          concertFacade.reserveConcertSeatWithDistributedLock(concertSeatId, userId);
+        });
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(
+            ErrorType.Concert.CONCERT_SEAT_ALREADY_RESERVED);
+      }
+
+      @Test
+      @DisplayName("콘서트 좌석 예약 성공")
+      void shouldSuccessfullyReserveConcertSeat() {
+        // given
+        final Concert concert = concertJpaRepository.save(
+            Concert.builder().title("title").description("description").build());
+        final Long concertId = concert.getId();
+
+        final ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(
+            ConcertSchedule.builder().concertId(concertId)
+                .concertAt(LocalDateTime.now().plusDays(1)).reservationStartAt(LocalDateTime.now())
+                .reservationEndAt(LocalDateTime.now().plusMinutes(1)).build());
+        final Long concertScheduleId = concertSchedule.getId();
+
+        final ConcertSeat concertSeat = concertSeatJpaRepository.save(
+            ConcertSeat.builder().concertScheduleId(concertScheduleId).number(1).price(100)
+                .isReserved(false).build());
+        final Long concertSeatId = concertSeat.getId();
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+
+        // when
+        final Reservation result = concertFacade.reserveConcertSeatWithDistributedLock(
+            concertSeatId, userId);
+
+        // then
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getConcertSeatId()).isEqualTo(concertSeatId);
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getStatus()).isEqualTo(ReservationStatus.WAITING);
+        assertThat(result.getCreatedAt()).isNotNull();
+        assertThat(result.getUpdatedAt()).isNull();
+
+        final ConcertSeat updatedConcertSeat = concertSeatJpaRepository.findById(concertSeatId)
+            .get();
+
+        assertThat(updatedConcertSeat.getIsReserved()).isTrue();
+      }
+
+    }
   }
 
 

--- a/src/test/java/com/example/hhplus/concert/application/UserFacadeTest.java
+++ b/src/test/java/com/example/hhplus/concert/application/UserFacadeTest.java
@@ -41,209 +41,664 @@ class UserFacadeTest {
   @DisplayName("사용자 지갑 잔액 충전")
   class ChargeUserWalletAmount {
 
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - userId가 null")
-    void shouldThrowUserIdMustNotBeNullException() {
-      // given
-      final Long userId = null;
-      final Long walletId = 1L;
-      final Integer amount = 1000;
+    @Nested
+    @DisplayName("사용자 지갑 잔액 충전 비관적락 테스트")
+    class ChargeUserWalletAmountWithPessimisticLock {
 
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - userId가 null")
+      void shouldThrowUserIdMustNotBeNullException() {
+        // given
+        final Long userId = null;
+        final Long walletId = 1L;
+        final Integer amount = 1000;
 
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - walletId가 null")
+      void shouldThrowWalletIdMustNotBeNullException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
+        final Long walletId = null;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 null")
+      void shouldThrowAmountMustNotBeNullException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = null;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0보다 작음")
+      void shouldThrowAmountMustBePositiveException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = -1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0")
+      void shouldThrowAmountMustNotBeZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = 0;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 사용자가 존재하지 않음")
+      void shouldThrowUserNotFoundException() {
+        // given
+        final Long userId = 1L;
+        final Long walletId = 1L;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑이 존재하지 않음")
+      void shouldThrowWalletNotFoundException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long walletId = 1L;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(user.getId(), walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND);
+      }
+
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑의 사용자와 요청한 사용자가 다름")
+      void shouldThrowWalletUserNotMatchException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId() + 1).build());
+        walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0보다 작음")
+      void shouldThrowAmountLessThanZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Integer amount = -1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0")
+      void shouldThrowAmountZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Integer amount = 0;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 한도 초과")
+      void shouldThrowAmountExceedLimitException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(0).build());
+        final Integer amount = UserConstants.MAX_WALLET_AMOUNT + 1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 성공")
+      void shouldSuccessfullyChargeUserWalletAmount() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(0).build());
+        final Integer amount = UserConstants.MAX_WALLET_AMOUNT;
+
+        // when
+        final Wallet result = userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(),
+            amount);
+
+        // then
+        assertThat(result.getAmount()).isEqualTo(wallet.getAmount() + amount);
+      }
+
     }
 
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - walletId가 null")
-    void shouldThrowWalletIdMustNotBeNullException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Long userId = user.getId();
-      walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
-      final Long walletId = null;
-      final Integer amount = 1000;
+    @Nested
+    @DisplayName("사용자 지갑 잔액 충전 낙관적락 테스트")
+    class ChargeUserWalletAmountWithOptimisticLock {
 
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - userId가 null")
+      void shouldThrowUserIdMustNotBeNullException() {
+        // given
+        final Long userId = null;
+        final Long walletId = 1L;
+        final Integer amount = 1000;
 
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - walletId가 null")
+      void shouldThrowWalletIdMustNotBeNullException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
+        final Long walletId = null;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 null")
+      void shouldThrowAmountMustNotBeNullException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = null;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0보다 작음")
+      void shouldThrowAmountMustBePositiveException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = -1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0")
+      void shouldThrowAmountMustNotBeZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = 0;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 사용자가 존재하지 않음")
+      void shouldThrowUserNotFoundException() {
+        // given
+        final Long userId = 1L;
+        final Long walletId = 1L;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑이 존재하지 않음")
+      void shouldThrowWalletNotFoundException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long walletId = 1L;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(user.getId(), walletId,
+                amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND);
+      }
+
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑의 사용자와 요청한 사용자가 다름")
+      void shouldThrowWalletUserNotMatchException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId() + 1).build());
+        walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(user.getId(), wallet.getId(),
+                amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0보다 작음")
+      void shouldThrowAmountLessThanZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Integer amount = -1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(user.getId(), wallet.getId(),
+                amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0")
+      void shouldThrowAmountZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Integer amount = 0;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(user.getId(), wallet.getId(),
+                amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 한도 초과")
+      void shouldThrowAmountExceedLimitException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(0).build());
+        final Integer amount = UserConstants.MAX_WALLET_AMOUNT + 1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithOptimisticLock(user.getId(), wallet.getId(),
+                amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 성공")
+      void shouldSuccessfullyChargeUserWalletAmount() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(0).build());
+        final Integer amount = UserConstants.MAX_WALLET_AMOUNT;
+
+        // when
+        final Wallet result = userFacade.chargeUserWalletAmountWithOptimisticLock(user.getId(),
+            wallet.getId(),
+            amount);
+
+        // then
+        assertThat(result.getAmount()).isEqualTo(wallet.getAmount() + amount);
+      }
     }
 
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 null")
-    void shouldThrowAmountMustNotBeNullException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Long userId = user.getId();
-      final Wallet wallet = walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
-      final Long walletId = wallet.getId();
-      final Integer amount = null;
+    @Nested
+    @DisplayName("사용자 지갑 잔액 충전 분산락 테스트")
+    class ChargeUserWalletAmountWithDistributionLock {
 
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - userId가 null")
+      void shouldThrowUserIdMustNotBeNullException() {
+        // given
+        final Long userId = null;
+        final Long walletId = 1L;
+        final Integer amount = 1000;
 
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.KEY_NOT_FOUND_OR_NULL);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - walletId가 null")
+      void shouldThrowWalletIdMustNotBeNullException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
+        final Long walletId = null;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 null")
+      void shouldThrowAmountMustNotBeNullException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = null;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0보다 작음")
+      void shouldThrowAmountMustBePositiveException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = -1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0")
+      void shouldThrowAmountMustNotBeZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long userId = user.getId();
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Long walletId = wallet.getId();
+        final Integer amount = 0;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 사용자가 존재하지 않음")
+      void shouldThrowUserNotFoundException() {
+        // given
+        final Long userId = 1L;
+        final Long walletId = 1L;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(userId, walletId, amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑이 존재하지 않음")
+      void shouldThrowWalletNotFoundException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Long walletId = 1L;
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(user.getId(), walletId,
+                amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND);
+      }
+
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑의 사용자와 요청한 사용자가 다름")
+      void shouldThrowWalletUserNotMatchException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId() + 1).build());
+        walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
+        final Integer amount = 1000;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(user.getId(),
+                wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0보다 작음")
+      void shouldThrowAmountLessThanZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Integer amount = -1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(user.getId(),
+                wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0")
+      void shouldThrowAmountZeroException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).build());
+        final Integer amount = 0;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(user.getId(),
+                wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 실패 - 한도 초과")
+      void shouldThrowAmountExceedLimitException() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(0).build());
+        final Integer amount = UserConstants.MAX_WALLET_AMOUNT + 1;
+
+        // when
+        final CoreException result = assertThrows(CoreException.class,
+            () -> userFacade.chargeUserWalletAmountWithDistributionLock(user.getId(),
+                wallet.getId(), amount));
+
+        // then
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT);
+      }
+
+      @Test
+      @DisplayName("사용자 지갑 잔액 충전 성공")
+      void shouldSuccessfullyChargeUserWalletAmount() {
+        // given
+        final User user = userJpaRepository.save(User.builder().name("name").build());
+        final Wallet wallet = walletJpaRepository.save(
+            Wallet.builder().userId(user.getId()).amount(0).build());
+        final Integer amount = UserConstants.MAX_WALLET_AMOUNT;
+
+        // when
+        final Wallet result = userFacade.chargeUserWalletAmountWithDistributionLock(user.getId(),
+            wallet.getId(),
+            amount);
+
+        // then
+        assertThat(result.getAmount()).isEqualTo(wallet.getAmount() + amount);
+      }
     }
 
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0보다 작음")
-    void shouldThrowAmountMustBePositiveException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Long userId = user.getId();
-      final Wallet wallet = walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
-      final Long walletId = wallet.getId();
-      final Integer amount = -1;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
-    }
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - amount가 0")
-    void shouldThrowAmountMustNotBeZeroException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Long userId = user.getId();
-      final Wallet wallet = walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
-      final Long walletId = wallet.getId();
-      final Integer amount = 0;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
-    }
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - 사용자가 존재하지 않음")
-    void shouldThrowUserNotFoundException() {
-      // given
-      final Long userId = 1L;
-      final Long walletId = 1L;
-      final Integer amount = 1000;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(userId, walletId, amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.USER_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑이 존재하지 않음")
-    void shouldThrowWalletNotFoundException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Long walletId = 1L;
-      final Integer amount = 1000;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(user.getId(), walletId, amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_FOUND);
-    }
-
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - 지갑의 사용자와 요청한 사용자가 다름")
-    void shouldThrowWalletUserNotMatchException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Wallet wallet = walletJpaRepository.save(
-          Wallet.builder().userId(user.getId() + 1).build());
-      walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
-      final Integer amount = 1000;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.WALLET_NOT_MATCH_USER);
-    }
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0보다 작음")
-    void shouldThrowAmountLessThanZeroException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Wallet wallet = walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
-      final Integer amount = -1;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
-    }
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - 충전 금액이 0")
-    void shouldThrowAmountZeroException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Wallet wallet = walletJpaRepository.save(Wallet.builder().userId(user.getId()).build());
-      final Integer amount = 0;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
-    }
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 실패 - 한도 초과")
-    void shouldThrowAmountExceedLimitException() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Wallet wallet = walletJpaRepository.save(
-          Wallet.builder().userId(user.getId()).amount(0).build());
-      final Integer amount = UserConstants.MAX_WALLET_AMOUNT + 1;
-
-      // when
-      final CoreException result = assertThrows(CoreException.class,
-          () -> userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount));
-
-      // then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.User.EXCEED_LIMIT_AMOUNT);
-    }
-
-    @Test
-    @DisplayName("사용자 지갑 잔액 충전 성공")
-    void shouldSuccessfullyChargeUserWalletAmount() {
-      // given
-      final User user = userJpaRepository.save(User.builder().name("name").build());
-      final Wallet wallet = walletJpaRepository.save(
-          Wallet.builder().userId(user.getId()).amount(0).build());
-      final Integer amount = UserConstants.MAX_WALLET_AMOUNT;
-
-      // when
-      final Wallet result = userFacade.chargeUserWalletAmount(user.getId(), wallet.getId(), amount);
-
-      // then
-      assertThat(result.getAmount()).isEqualTo(wallet.getAmount() + amount);
-    }
 
   }
 

--- a/src/test/java/com/example/hhplus/concert/domain/user/dto/UserCommandTest.java
+++ b/src/test/java/com/example/hhplus/concert/domain/user/dto/UserCommandTest.java
@@ -102,30 +102,30 @@ class UserCommandTest {
   class WithdrawUserWalletAmountCommandTest {
 
     @Test
-    @DisplayName("잔액 출금 Command 생성 실패 - userId가 null인 경우")
+    @DisplayName("잔액 출금 Command 생성 실패 - walletId가 null인 경우")
     void shouldThrowBusinessExceptionWhenUserIdIsNull() {
       // given
-      final Long userId = null;
+      final Long walletId = null;
       final Integer amount = 1000;
 
       // when
       final CoreException exception = assertThrows(CoreException.class,
-          () -> new WithdrawUserWalletAmountCommand(userId, amount));
+          () -> new WithdrawUserWalletAmountCommand(walletId, amount));
 
       // then
-      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.USER_ID_MUST_NOT_BE_NULL);
+      assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.WALLET_ID_MUST_NOT_BE_NULL);
     }
 
     @Test
     @DisplayName("잔액 출금 Command 생성 실패 - 금액이 null인 경우")
     void shouldThrowBusinessExceptionWhenAmountIsNull() {
       // given
-      final Long userId = 1L;
+      final Long walletId = 1L;
       final Integer amount = null;
 
       // when
       final CoreException exception = assertThrows(CoreException.class,
-          () -> new WithdrawUserWalletAmountCommand(userId, amount));
+          () -> new WithdrawUserWalletAmountCommand(walletId, amount));
 
       // then
       assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_NOT_BE_NULL);
@@ -135,12 +135,12 @@ class UserCommandTest {
     @DisplayName("잔액 출금 Command 생성 실패 - 금액이 음수인 경우")
     void shouldThrowBusinessExceptionWhenAmountIsNegative() {
       // given
-      final Long userId = 1L;
+      final Long walletId = 1L;
       final Integer amount = -1;
 
       // when
       final CoreException exception = assertThrows(CoreException.class,
-          () -> new WithdrawUserWalletAmountCommand(userId, amount));
+          () -> new WithdrawUserWalletAmountCommand(walletId, amount));
 
       // then
       assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
@@ -150,12 +150,12 @@ class UserCommandTest {
     @DisplayName("잔액 출금 Command 생성 실패 - 금액이 0인 경우")
     void shouldThrowBusinessExceptionWhenAmountIsZero() {
       // given
-      final Long userId = 1L;
+      final Long walletId = 1L;
       final Integer amount = 0;
 
       // when
       final CoreException exception = assertThrows(CoreException.class,
-          () -> new WithdrawUserWalletAmountCommand(userId, amount));
+          () -> new WithdrawUserWalletAmountCommand(walletId, amount));
 
       // then
       assertThat(exception.getErrorType()).isEqualTo(ErrorType.User.AMOUNT_MUST_BE_POSITIVE);
@@ -165,16 +165,16 @@ class UserCommandTest {
     @DisplayName("잔액 출금 Command 생성 성공")
     void shouldSuccessfullyCreateWithdrawUserWalletAmountCommand() {
       // given
-      final Long userId = 1L;
+      final Long walletId = 1L;
       final Integer amount = 1000;
 
       // when
-      final WithdrawUserWalletAmountCommand command = new WithdrawUserWalletAmountCommand(userId,
+      final WithdrawUserWalletAmountCommand command = new WithdrawUserWalletAmountCommand(walletId,
           amount);
 
       // then
       assertThat(command).isNotNull();
-      assertThat(command.userId()).isEqualTo(userId);
+      assertThat(command.walletId()).isEqualTo(walletId);
       assertThat(command.amount()).isEqualTo(amount);
     }
   }

--- a/src/test/java/resource/application.yml
+++ b/src/test/java/resource/application.yml
@@ -20,3 +20,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         show_sql: true # SQL 쿼리 출력 여부
         format_sql: true # SQL 쿼리 포맷팅 여부
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
# 요구사항

- [x] DB Lock 을 활용한 동시성 제어 방식 에서 해당 비즈니스 로직에서 적합하다고 판단하여 차용한 동시성 제어 방식을 구현하여 비즈니스 로직에 적용하고, 통합테스트 등으로 이를 검증하는 코드 작성 및 제출

# 작업 내용

redis 분산락 추가 (https://github.com/hhpb-code/hhplus-concert/pull/29/commits/b10f7a57548426151f058c55608b33b658882476, https://github.com/hhpb-code/hhplus-concert/pull/29/commits/4e7849e756c73896474cb3b5fc191c27f3a45f67)

https://github.com/hhpb-code/hhplus-concert/pull/28 에서 좌석예약, 잔액 충전, 잔액 결제(예약 내역 결제)에 대해 분석하여 적용할 락을 정했습니다.

좌석 예약 분산락 추가 및 테스트 (https://github.com/hhpb-code/hhplus-concert/pull/29/commits/7d6cc1402aaaf6d2a019b94f57ae6ab687765ebc)
사용자 잔액 충전 낙관적락, 분산락 추가 및 테스트 (https://github.com/hhpb-code/hhplus-concert/pull/29/commits/9a1019e711f357d07bdaa402636a6b8e9329efac)
예약 내역 결제 낙관적락, 분산락 추가 및 테스트 (https://github.com/hhpb-code/hhplus-concert/pull/29/commits/62d48764865b2121202eb9efbf3952b1118e08be)

선택 동시성 제어 방법 API에 적용 (https://github.com/hhpb-code/hhplus-concert/pull/29/commits/bc3da392b781320b2e8059d6e13189d7c878a6c5)
좌석 예약 - 낙관적락
잔액 충전 - 분산락, 낙관적락
잔액 결제(예약 내역 결제) - 분산락, 낙관적락

## 코드 구현

각 usecase 별 비관적락, 낙관적락, 분산락 구현 및 통합 + 동시성 테스트를 진행했습니다.
사실 잔액과 좌석 entity에 @Version 어노테이션에 의해 모든 동시성제어에 낙관적락이 포함되어있습니다.
하지만 비관적락과 분산락의 경우 낙관적락에 의한 충돌이 안나오고 나온다면 error로 생각하고 작성했기에 감안해서 봐주시면 좋을 것 같습니다.

# 리뷰포인트

- 리뷰어님들이 생각했을 때 더 좋은 패턴이 보일 경우 공유해주시면 좋을 것 같습니다.
- 테스트 코드의 추가로 있으면 좋을 부분 또는 불 필요해 보이는 부분도 확인 부탁드립니다.